### PR TITLE
Generate command name using 'x-ms-cmdlet-name' petterned field and add error handling scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,41 +23,42 @@ Note: Please run this steps on a Windows 10 Anniversary Update or Windows Server
 
 
 ```code
-    git clone https://github.com/PowerShell/PSSwagger.git
-    ```
+git clone https://github.com/PowerShell/PSSwagger.git
+```
 
 2. Ensure you AutoRest version 0.16.0 installed
 
-   ```powershell
-   Install-Package -Name AutoRest -Source https://www.nuget.org/api/v2 -RequiredVersion 0.16.0 -Scope CurrentUser
-   ```
+```powershell
+Install-Package -Name AutoRest -Source https://www.nuget.org/api/v2 -RequiredVersion 0.16.0 -Scope CurrentUser
+```
    
 3. Ensure AutoRest.exe is in $env:Path
 
-   ```powershell
-   $env:path += ";$env:localappdata\PackageManagement\NuGet\Packages\AutoRest.0.16.0\tools"
-   ```
+```powershell
+$env:path += ";$env:localappdata\PackageManagement\NuGet\Packages\AutoRest.0.16.0\tools"
+```
 
 4. Run the following in a PowerShell console from the directory where you cloned PSSwagger in:
 
-   ```powershell
-   Import-Module .\PSSwagger\PSSwagger.psd1
-   $param = @{
-       SwaggerSpecUri = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-batch/2015-12-01/swagger/BatchManagement.json'
-       Path           = 'C:\Temp\generatedmodule\'
-       ModuleName     = 'Generated.Azure.BatchManagement'
-   }
-   Export-CommandFromSwagger @param
-   ```
+```powershell
+Import-Module .\PSSwagger\PSSwagger.psd1
+$param = @{
+    SwaggerSpecUri = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-batch/2015-12-01/swagger/BatchManagement.json'
+    Path           = 'C:\Temp\generatedmodule\'
+    ModuleName     = 'Generated.Azure.BatchManagement'
+}
+Export-CommandFromSwagger @param
+```
 
 After step 4, the module will be in `C:\Temp\GeneratedModule\Generated.Azure.BatchManagement ($param.Path)` folder.
 
 Before importing that module and using it, you need to import `Generated.Azure.Common.Helpers` module which is under PSSwagger folder.
-    ```PowerShell
-    Import-Module .\PSSwagger\Generated.Azure.Common.Helpers
-    Import-Module "$($param.Path)\$($param.ModuleName)"
-    Get-Command -Module $param.ModuleName
-    ```
+    
+```powershell
+Import-Module .\PSSwagger\Generated.Azure.Common.Helpers
+Import-Module "$($param.Path)\$($param.ModuleName)"
+Get-Command -Module $param.ModuleName
+```
 ## Upcoming additions
 
 1. Enabe PowerShell Best practices


### PR DESCRIPTION
- Added logic to retrieve the command name for each Swagger spec path from 'x-ms-cmdlet-name' petterned field.
- Ensured that generated command noun suffix doesn't have the repeated terms like *ResourceResource.
- Added Failure, Cancel and Success scenarios in the generated Swagger command function.
- Added error handling for downloading the specified swagger specification
- Updated readme.md
