### PR TITLE
Multiple improvments for generating the PowerShell commands for Azure Swagger Specifications

### DIFF
--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -67,45 +67,169 @@ function Export-CommandFromSwagger
         throw "Swagger file $SwaggerSpecPath does not exist. Check the path"
     }
 
-    $outputDirectory = $Path
-    if (-not $Path.EndsWith($ModuleName, [System.StringComparison]::OrdinalIgnoreCase))
-    {
-        $outputDirectory = Join-Path -Path $Path -ChildPath $ModuleName
+    $jsonObject = ConvertFrom-Json ((Get-Content $SwaggerSpecPath) -join [Environment]::NewLine) -ErrorAction Stop
+
+    # Populate the metadata, definitions and parameters from the provided Swagger specification
+    $SwaggerSpecDefinitionsAndParameters = Get-SwaggerSpecDefinitionAndParameter -SwaggerSpecJsonObject $jsonObject -ModuleName $ModuleName
+    
+    $outputDirectory = $Path.TrimEnd('\').TrimEnd('/')
+
+    if($PSVersionTable.PSVersion -lt '5.0.0') {
+        if (-not $outputDirectory.EndsWith($ModuleName, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $outputDirectory = Join-Path -Path $outputDirectory -ChildPath $ModuleName
+        }
+    } else {
+        $ModuleVersion = $SwaggerSpecDefinitionsAndParameters['Version']
+        $ModuleNameandVersionFolder = Join-Path -Path $ModuleName -ChildPath $ModuleVersion
+
+        if ($outputDirectory.EndsWith($ModuleName, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $outputDirectory = Join-Path -Path $outputDirectory -ChildPath $ModuleVersion
+        } elseif (-not $outputDirectory.EndsWith($ModuleNameandVersionFolder, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $outputDirectory = Join-Path -Path $outputDirectory -ChildPath $ModuleNameandVersionFolder
+        }
     }
 
     $null = New-Item -ItemType Directory $outputDirectory -Force -ErrorAction Stop
 
-    $jsonObject = ConvertFrom-Json ((Get-Content $SwaggerSpecPath) -join [Environment]::NewLine) -ErrorAction Stop
-
-    # Populate the metadata, definitions and parameters from the provided Swagger specification
-    $SwaggerSpecDefinitionsAndParameters = Get-SwaggerSpecDefinitionsAndParameters -SwaggerSpecJsonObject $jsonObject -ModuleName $ModuleName
-
-    $namespace = $SwaggerSpecDefinitionsAndParameters['Namespace']
+    $Namespace = $SwaggerSpecDefinitionsAndParameters['Namespace']
     ConvertTo-CsharpCode -SwaggerSpecPath $SwaggerSpecPath `
                          -Path $outputDirectory `
                          -ModuleName $ModuleName `
-                         -NameSpace $namespace `
+                         -NameSpace $Namespace `
                          -UseAzureCsharpGenerator:$UseAzureCsharpGenerator
 
-    $modulePath = Join-Path $outputDirectory "$ModuleName.psm1"
+    $FunctionsToExport = @()
+    $GeneratedCommandsName = 'Generated.PowerShell.Commands'
+    $SwaggerPathCommandsPath = Join-Path -Path (Join-Path -Path $outputDirectory -ChildPath $GeneratedCommandsName) -ChildPath 'SwaggerPathCommands'
 
-    $cmds = New-Object -TypeName System.Collections.ObjectModel.Collection[string]
-
-    # Handle the paths
+    # Handle the Paths
     $jsonObject.Paths.PSObject.Properties | ForEach-Object {
         $jsonPathObject = $_.Value
         $jsonPathObject.psobject.Properties | ForEach-Object {
-               $cmd = New-SwaggerSpecCommand $_.Value -UseAzureCsharpGenerator:$UseAzureCsharpGenerator -SwaggerSpecDefinitionsAndParameters $SwaggerSpecDefinitionsAndParameters
-               if($cmd) {
-                   Write-Verbose $cmd
-                   $cmds.Add($cmd)
-               }
+               $FunctionsToExport += New-SwaggerSpecPathCommand -JsonPathItemObject $_.Value `
+                                                                -GeneratedCommandsPath $SwaggerPathCommandsPath `
+                                                                -UseAzureCsharpGenerator:$UseAzureCsharpGenerator `
+                                                                -SwaggerSpecDefinitionsAndParameters $SwaggerSpecDefinitionsAndParameters
             } # jsonPathObject
     } # jsonObject
 
-    $cmds | Out-File $modulePath -Encoding ASCII
+    $SwaggerDefinitionCommandsPath = Join-Path -Path (Join-Path -Path $outputDirectory -ChildPath $GeneratedCommandsName) -ChildPath 'SwaggerDefinitionCommands'
 
-    New-ModuleManifestUtility -Path $outputDirectory -SwaggerSpecDefinitionsAndParameters $SwaggerSpecDefinitionsAndParameters
+    # Handle the Definitions
+    $DefinitionFunctionsDetails = @{}
+    $jsonObject.Definitions.PSObject.Properties | ForEach-Object {
+        Get-SwaggerSpecDefinitionInfo -JsonDefinitionItemObject $_ -Namespace $Namespace -DefinitionFunctionsDetails $DefinitionFunctionsDetails
+    }
+
+    # Expand the definition parameters from 'AllOf' definitions and x_ms_client-flatten declarations.
+    $ExpandedAllDefinitions = $false
+
+    while(-not $ExpandedAllDefinitions)
+    {
+        $ExpandedAllDefinitions = $true
+
+        $DefinitionFunctionsDetails.Keys | ForEach-Object {
+            
+            $FunctionDetails = $DefinitionFunctionsDetails[$_]
+
+            if(-not $FunctionDetails.ExpandedParameters)
+            {
+                Write-Verbose -Message "Trying to expand the $($FunctionDetails.Name) defnition."
+
+                $Unexpanded_AllOf_DefinitionNames = $FunctionDetails.Unexpanded_AllOf_DefinitionNames | ForEach-Object {
+                                                        $ReferencedDefinitionName = $_
+                                                        if($DefinitionFunctionsDetails.ContainsKey($ReferencedDefinitionName) -and
+                                                           $DefinitionFunctionsDetails[$ReferencedDefinitionName].ExpandedParameters)
+                                                        {
+                                                            $RefFunctionDetails = $DefinitionFunctionsDetails[$ReferencedDefinitionName]
+                                                
+                                                            $RefFunctionDetails.ParametersTable.Keys | ForEach-Object {
+                                                                $RefParameterName = $_
+                                                                if($FunctionDetails.ParametersTable.ContainsKey($RefParameterName))
+                                                                {
+                                                                    Throw "Same property name should not be defined in a definition with AllOf inheritance."
+                                                                }
+                                                                else
+                                                                {
+                                                                    $FunctionDetails.ParametersTable[$RefParameterName] = $RefFunctionDetails.ParametersTable[$RefParameterName]
+                                                                }
+                                                            }
+                                                        }
+                                                        else
+                                                        {
+                                                            $_
+                                                        }
+                                                    }
+
+                $Unexpanded_x_ms_client_flatten_DefinitionNames = $FunctionDetails.Unexpanded_x_ms_client_flatten_DefinitionNames | ForEach-Object {
+                                                                        $ReferencedDefinitionName = $_
+                                                                        if($DefinitionFunctionsDetails.ContainsKey($ReferencedDefinitionName) -and
+                                                                           $DefinitionFunctionsDetails[$ReferencedDefinitionName].ExpandedParameters)
+                                                                        {
+                                                                            $RefFunctionDetails = $DefinitionFunctionsDetails[$ReferencedDefinitionName]
+                                                
+                                                                            $RefFunctionDetails.ParametersTable.Keys | ForEach-Object {
+                                                                                $RefParameterName = $_
+                                                                                if($FunctionDetails.ParametersTable.ContainsKey($RefParameterName))
+                                                                                {
+                                                                                    $ParameterName = $FunctionDetails.Name + $RefParameterName
+
+                                                                                    $FunctionDetails.ParametersTable[$ParameterName] = $RefFunctionDetails.ParametersTable[$RefParameterName]
+                                                                                    $FunctionDetails.ParametersTable[$ParameterName].Name = $ParameterName
+                                                                                }
+                                                                                else
+                                                                                {
+                                                                                    $FunctionDetails.ParametersTable[$RefParameterName] = $RefFunctionDetails.ParametersTable[$RefParameterName]
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                        else
+                                                                        {
+                                                                            $_
+                                                                        }
+                                                                    }
+
+
+                $FunctionDetails.ExpandedParameters = (-not $Unexpanded_AllOf_DefinitionNames -and -not $Unexpanded_x_ms_client_flatten_DefinitionNames)
+                $FunctionDetails.Unexpanded_AllOf_DefinitionNames = $Unexpanded_AllOf_DefinitionNames
+                $FunctionDetails.Unexpanded_x_ms_client_flatten_DefinitionNames = $Unexpanded_x_ms_client_flatten_DefinitionNames
+
+                if(-not $FunctionDetails.ExpandedParameters)
+                {
+                    Write-Verbose -Message "Unable to expand the $($FunctionDetails.Name) definition in current iteration."
+                    $ExpandedAllDefinitions = $false
+                }
+            } # ExpandedParameters
+        } # Foeach-Object
+    } # while()
+
+    $DefinitionFunctionsDetails.Keys | ForEach-Object {
+        
+        $FunctionDetails = $DefinitionFunctionsDetails[$_]
+
+        # Denifitions defined as x_ms_client_flatten are not used as an object anywhere. 
+        # Also AutoRest doesn't generate a Model class for the definitions declared as x_ms_client_flatten for other definitions.
+        if(-not $FunctionDetails.IsUsedAs_x_ms_client_flatten) {
+            $FunctionsToExport += New-SwaggerSpecDefinitionCommand -FunctionDetails $FunctionDetails `
+                                                                   -GeneratedCommandsPath $SwaggerDefinitionCommandsPath `
+                                                                   -Namespace $Namespace
+        }
+    }
+
+    $RootModuleContents = @'
+Microsoft.PowerShell.Core\Set-StrictMode -Version Latest
+
+Get-ChildItem -Path "`$PSScriptRoot\$GeneratedCommandsName" -Recurse -Filter *.ps1 -File | ForEach-Object { . `$_.FullName}
+'@
+    $RootModuleFilePath = Join-Path $outputDirectory "$ModuleName.psm1"
+    Out-File -FilePath $RootModuleFilePath `
+             -InputObject $ExecutionContext.InvokeCommand.ExpandString($RootModuleContents)`
+             -Encoding ascii `
+             -Force
+
+    New-ModuleManifestUtility -Path $outputDirectory `
+                              -FunctionsToExport $FunctionsToExport `
+                              -SwaggerSpecDefinitionsAndParameters $SwaggerSpecDefinitionsAndParameters
 }
 
 #region Cmdlet Generation Helpers
@@ -114,14 +238,18 @@ function Export-CommandFromSwagger
 .DESCRIPTION
   Generates a cmdlet given a JSON custom object (from paths)
 #>
-function New-SwaggerSpecCommand
+function New-SwaggerSpecPathCommand
 {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true)]
         [PSObject]
         $JsonPathItemObject,
-        
+
+        [Parameter(Mandatory=$true)]
+        [string] 
+        $GeneratedCommandsPath,
+
         [Parameter(Mandatory=$false)]
         [switch]
         $UseAzureCsharpGenerator,
@@ -131,12 +259,12 @@ function New-SwaggerSpecCommand
         $SwaggerSpecDefinitionsAndParameters 
     )
 
-$helpDescStr = @'
+    $helpDescStr = @'
 .DESCRIPTION
     $description
 '@
 
-$advFnSignature = @'
+    $advFnSignature = @'
 <#
 $commandHelp
 $paramHelp
@@ -151,20 +279,22 @@ function $commandName
 }
 '@
 
-$parameterDefString = @'
+    $parameterDefString = @'
     
     [Parameter(Mandatory = $isParamMandatory)]
-    [$paramType] $paramName,
+    [$paramType]
+    $paramName,
+
 '@
 
-$helpParamStr = @'
+    $helpParamStr = @'
 
 .PARAMETER $parameterName
     $pDescription
 
 '@
 
-$functionBodyStr = @'
+    $functionBodyStr = @'
 
     `$serviceCredentials =  Get-AzServiceCredential
     `$subscriptionId = Get-AzSubscriptionId
@@ -175,9 +305,9 @@ $functionBodyStr = @'
     $clientName.SubscriptionId = `$subscriptionId
     
     Write-Verbose 'Performing operation $methodName on $clientName.'
-    `$taskResult = $clientName.$operations.$methodName($requiredParamList)
+    `$taskResult = $clientName$operations.$methodName($requiredParamList)
     Write-Verbose "Waiting for the operation to complete."
-    `$taskResult.AsyncWaitHandle.WaitOne() | out-null
+    `$null = `$taskResult.AsyncWaitHandle.WaitOne()
     Write-Debug "`$(`$taskResult | Out-String)"
 
     if(`$taskResult.IsFaulted) {
@@ -189,15 +319,28 @@ $functionBodyStr = @'
     } else {
         Write-Verbose 'Operation completed successfully.'
 
-        if(`$taskResult.Result -and `$taskResult.Result.Body) {
+        if(`$taskResult.Result -and 
+           (Get-Member -InputObject `$taskResult.Result -Name 'Body') -and
+           `$taskResult.Result.Body) 
+        {
             Write-Verbose -Message "`$(`$taskResult.Result.Body | Out-String)"
             `$taskResult.Result.Body
+
+            if((Get-Member -InputObject `$taskResult.Result.Body -Name 'ProvisioningState') -and 
+               (`$taskResult.Result.Body.ProvisioningState -ne 'Succeeded')) 
+            {
+                Write-Warning -Message "Please wait until the provisioning state of resource is updated to 'Succeeded' state. Consider using the corresponding Get command to get the provisioning state."
+            } else {
+                Write-Verbose -Message "Successfully provisioned the specified resource."
+            }
+        } else {
+            Write-Warning -Message "Please wait until the specified resource gets provisioned. Consider using the corresponding Get command to get the provisioning state."
         }
     }
-    
+   
 '@
  
-    $commandName = Get-SwaggerCommandName $JsonPathItemObject
+    $commandName = Get-SwaggerPathCommandName $JsonPathItemObject
     $description = ""
     if((Get-Member -InputObject $JsonPathItemObject -Name 'Description') -and $JsonPathItemObject.Description) {
         $description = $JsonPathItemObject.Description
@@ -209,6 +352,7 @@ $functionBodyStr = @'
     $requiredParamList = @()
     $optionalParamList = @()
     $body = ""
+    $Namespace = $SwaggerSpecDefinitionsAndParameters['namespace']
 
     # Handle the function parameters
     #region Function Parameters
@@ -217,9 +361,27 @@ $functionBodyStr = @'
         if((Get-Member -InputObject $_ -Name 'Name') -and $_.Name)
         {
             $isParamMandatory = '$false'
-            $parameterName = Remove-SpecialCharecters -Name $_.Name
+            $parameterName = Get-PascalCasedString -Name $_.Name
             $paramName = "`$$parameterName" 
-            $paramType = if ( (Get-Member -InputObject $_ -Name 'Type') -and $_.Type) { $_.Type } else { "object" }
+            $paramType = if ( (Get-Member -InputObject $_ -Name 'Type') -and $_.Type)
+                         {
+                            # Use the format as parameter type if that is available as a type in PowerShell
+                            if ( (Get-Member -InputObject $_ -Name 'Format') -and $_.Format -and ($null -ne ($_.Format -as [Type])) ) 
+                            {
+                                $_.Format
+                            }
+                            else {
+                                $_.Type
+                            }
+                         } elseif ( (Get-Member -InputObject $_ -Name 'Schema') -and ($_.Schema) -and
+                             (Get-Member -InputObject $_.Schema -Name '$ref') -and ($_.Schema.'$ref') )
+                         {
+                            $ReferenceParameterValue = $_.Schema.'$ref'
+                            $Namespace + '.Models.' + $ReferenceParameterValue.Substring( $( $ReferenceParameterValue.LastIndexOf('/') ) + 1 )
+                         }
+                         else {
+                             'object'
+                         }
             if ($_.Required)
             { 
                 $isParamMandatory = '$true'
@@ -243,7 +405,7 @@ $functionBodyStr = @'
         }
     }# $parametersSpec
 
-    $paramblock = $paramBlock.TrimEnd(",")
+    $paramblock = $paramBlock.TrimEnd().TrimEnd(",")
     $requiredParamList = $requiredParamList -join ', '
     $optionalParamList = $optionalParamList -join ', '
 
@@ -253,7 +415,7 @@ $functionBodyStr = @'
     #region Function Body
     $infoVersion = $SwaggerSpecDefinitionsAndParameters['infoVersion']
     $modulePostfix = $SwaggerSpecDefinitionsAndParameters['infoName']
-    $fullModuleName = $SwaggerSpecDefinitionsAndParameters['namespace'] + '.' + $modulePostfix
+    $fullModuleName = $Namespace + '.' + $modulePostfix
     $clientName = '$' + $modulePostfix
     $apiVersion = ''
     if (-not $UseAzureCsharpGenerator)
@@ -261,28 +423,389 @@ $functionBodyStr = @'
         $apiVersion = '{0}.ApiVersion = "{1}"' -f $clientName,$infoVersion
     }
 
-    $operationName = $JsonPathItemObject.operationId.Split('_')[0]
-    $operationType = $JsonPathItemObject.operationId.Split('_')[1]
-    $operations = $operationName 
-    if ((-not $UseAzureCsharpGenerator) -and (Test-OperationNameInDefinitionList -Name $operationName -SwaggerSpecDefinitionsAndParameters $SwaggerSpecDefinitionsAndParameters))
-    { 
-        $operations = $operations + 'Operations'
+    $operationId = $JsonPathItemObject.operationId
+    $opIdValues = $operationId -split '_',2 
+    if(-not $opIdValues -or ($opIdValues.count -ne 2)) {
+        $methodName = $operationId + 'WithHttpMessagesAsync'
+        $operations = ''
+    } else {            
+        $operationName = $JsonPathItemObject.operationId.Split('_')[0]
+        $operationType = $JsonPathItemObject.operationId.Split('_')[1]
+        $operations = ".$operationName"
+        if ((-not $UseAzureCsharpGenerator) -and 
+            (Test-OperationNameInDefinitionList -Name $operationName -SwaggerSpecDefinitionsAndParameters $SwaggerSpecDefinitionsAndParameters))
+        { 
+            $operations = $operations + 'Operations'
+        }
+        $methodName = $operationType + 'WithHttpMessagesAsync'
     }
-    $methodName = $operationType + 'WithHttpMessagesAsync'
-    $operationVar = '$' + $operationName
 
     $body = $executionContext.InvokeCommand.ExpandString($functionBodyStr)
 
     #endregion Function Body
 
-    $executionContext.InvokeCommand.ExpandString($advFnSignature)
+    $CommandString = $executionContext.InvokeCommand.ExpandString($advFnSignature)
+    Write-Verbose $CommandString
+
+    if(-not (Test-Path -Path $GeneratedCommandsPath -PathType Container)) {
+        $null = New-Item -Path $GeneratedCommandsPath -ItemType Directory
+    }
+
+    $CommandFilePath = Join-Path -Path $GeneratedCommandsPath -ChildPath "$CommandName.ps1"
+    Out-File -InputObject $CommandString -FilePath $CommandFilePath -Encoding ascii -Force -Confirm:$false -WhatIf:$false
+
+    return $CommandName
+}
+
+<#
+.DESCRIPTION
+  Gets Definition function details.
+#>
+function Get-SwaggerSpecDefinitionInfo
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [PSObject]
+        $JsonDefinitionItemObject,
+
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject] 
+        $DefinitionFunctionsDetails,
+
+        [Parameter(Mandatory=$true)]
+        [string] 
+        $Namespace 
+    )
+
+    $Name = $JsonDefinitionItemObject.Name
+
+    $FunctionDescription = ""
+    if((Get-Member -InputObject $JsonDefinitionItemObject.Value -Name 'Description') -and 
+       $JsonDefinitionItemObject.Value.Description)
+    {
+        $FunctionDescription = $JsonDefinitionItemObject.Value.Description
+    }
+
+    $DefinitionTypeNamePrefix = "$Namespace.Models."
+
+    $x_ms_Client_flatten_DefinitionNames = @()
+    $AllOf_DefinitionNames = @()
+
+    $ParametersTable = @{}
+
+    if((Get-Member -InputObject $JsonDefinitionItemObject.Value -Name 'AllOf') -and 
+       $JsonDefinitionItemObject.Value.'AllOf')
+    {
+       $JsonDefinitionItemObject.Value.'AllOf' | ForEach-Object {
+           $AllOfRefFullName = $_.'$ref'
+           $AllOfRefName = $AllOfRefFullName.Substring( $( $AllOfRefFullName.LastIndexOf('/') ) + 1 )
+           $AllOf_DefinitionNames += $AllOfRefName
+                      
+           $ReferencedFunctionDetails = @{}
+           if($DefinitionFunctionsDetails.ContainsKey($AllOfRefName))
+           {
+               $ReferencedFunctionDetails = $DefinitionFunctionsDetails[$AllOfRefName]
+           }
+
+           $ReferencedFunctionDetails['Name'] = $AllOfRefName
+           $ReferencedFunctionDetails['IsUsedAs_AllOf'] = $true
+           $DefinitionFunctionsDetails[$AllOfRefName] = $ReferencedFunctionDetails
+       }
+    }
+
+    $JsonDefinitionItemObject.Value.properties.PSObject.Properties | ForEach-Object {
+
+        if((Get-Member -InputObject $_ -Name 'Name') -and $_.Name)
+        {
+            $ParameterJsonObject = $_.Value
+
+            $ParameterDetails = @{}
+
+            $IsParamMandatory = '$false'
+            $ValidateSetString = $null
+            $ParameterDescription = ''
+            $parameterName = Get-PascalCasedString -Name $_.Name
+            
+            $paramType = if ( (Get-Member -InputObject $ParameterJsonObject -Name 'Type') -and $ParameterJsonObject.Type)
+                         {
+                            # Use the format as parameter type if that is available as a type in PowerShell
+                            if ( (Get-Member -InputObject $ParameterJsonObject -Name 'Format') -and 
+                                 $ParameterJsonObject.Format -and 
+                                 ($null -ne ($ParameterJsonObject.Format -as [Type])) ) 
+                            {
+                                $ParameterJsonObject.Format
+                            }
+                            elseif ( ($ParameterJsonObject.Type -eq 'array') -and
+                                     (Get-Member -InputObject $ParameterJsonObject -Name 'Items') -and 
+                                     $ParameterJsonObject.Items)
+                            {
+                                if((Get-Member -InputObject $ParameterJsonObject.Items -Name '$ref') -and 
+                                   $ParameterJsonObject.Items.'$ref')
+                                {
+                                    $ReferenceTypeValue = $ParameterJsonObject.Items.'$ref'
+                                    $ReferenceTypeName = $ReferenceTypeValue.Substring( $( $ReferenceTypeValue.LastIndexOf('/') ) + 1 )
+                                    $DefinitionTypeNamePrefix + "$ReferenceTypeName[]"
+                                }
+                                elseif((Get-Member -InputObject $ParameterJsonObject.Items -Name 'Type') -and $ParameterJsonObject.Items.Type)
+                                {
+                                    "$($ParameterJsonObject.Items.Type)[]"
+                                }
+                                else
+                                {
+                                    $ParameterJsonObject.Type
+                                }                             
+                            }
+                            elseif ( ($ParameterJsonObject.Type -eq 'object') -and
+                                     (Get-Member -InputObject $ParameterJsonObject -Name 'AdditionalProperties') -and 
+                                     $ParameterJsonObject.AdditionalProperties)
+                            {
+                                $AdditionalPropertiesType = $ParameterJsonObject.AdditionalProperties.Type
+                                "System.Collections.Generic.Dictionary[[$AdditionalPropertiesType],[$AdditionalPropertiesType]]"
+                            }
+                            else
+                            {
+                                $ParameterJsonObject.Type
+                            }
+                         }
+                         elseif ( $parameterName -eq 'Properties' -and
+                                  (Get-Member -InputObject $ParameterJsonObject -Name 'x-ms-client-flatten') -and 
+                                  ($ParameterJsonObject.'x-ms-client-flatten') )
+                         {                         
+                             # 'x-ms-client-flatten' extension allows to flatten deeply nested properties into the current definition.
+                             # Users often provide feedback that they don't want to create multiple levels of properties to be able to use an operation. 
+                             # By applying the x-ms-client-flatten extension, you move the inner properties to the top level of your definition.
+
+                             $ReferenceParameterValue = $ParameterJsonObject.'$ref'
+                             $ReferenceDefinitionName = $ReferenceParameterValue.Substring( $( $ReferenceParameterValue.LastIndexOf('/') ) + 1 )
+
+                             $x_ms_Client_flatten_DefinitionNames += $ReferenceDefinitionName
+
+                             $ReferencedFunctionDetails = @{}
+                             if($DefinitionFunctionsDetails.ContainsKey($ReferenceDefinitionName))
+                             {
+                                 $ReferencedFunctionDetails = $DefinitionFunctionsDetails[$ReferenceDefinitionName]
+                             }
+
+                             $ReferencedFunctionDetails['Name'] = $ReferenceDefinitionName
+                             $ReferencedFunctionDetails['IsUsedAs_x_ms_client_flatten'] = $true
+                             $DefinitionFunctionsDetails[$ReferenceDefinitionName] = $ReferencedFunctionDetails
+                         }
+                         elseif ( (Get-Member -InputObject $ParameterJsonObject -Name '$ref') -and ($ParameterJsonObject.'$ref') )
+                         {
+                            $ReferenceParameterValue = $ParameterJsonObject.'$ref'
+                            $DefinitionTypeNamePrefix + $ReferenceParameterValue.Substring( $( $ReferenceParameterValue.LastIndexOf('/') ) + 1 )
+                         }
+                         else 
+                         {
+                             'object'
+                         }
+
+            if($paramType -eq 'Boolean')
+            {
+                $paramType = 'switch'
+            }
+
+            if ((Get-Member -InputObject $JsonDefinitionItemObject.Value -Name 'Required') -and 
+                $JsonDefinitionItemObject.Value.Required -and
+                ($JsonDefinitionItemObject.Value.Required -contains $parameterName) )
+            {
+                $IsParamMandatory = '$true'
+            }
+
+            if ((Get-Member -InputObject $ParameterJsonObject -Name 'Enum') -and $ParameterJsonObject.Enum)
+            {
+                if((Get-Member -InputObject $ParameterJsonObject -Name 'x-ms-enum') -and 
+                   $ParameterJsonObject.'x-ms-enum' -and 
+                   ($ParameterJsonObject.'x-ms-enum'.modelAsString -eq $false))
+                {
+                    $paramType = $DefinitionTypeNamePrefix + $ParameterJsonObject.'x-ms-enum'.Name
+                }
+                else
+                {
+                    $ValidateSet = $ParameterJsonObject.Enum
+                    $ValidateSetString = "'$($ValidateSet -join "', '")'"
+                }
+            }
+
+            if ((Get-Member -InputObject $ParameterJsonObject -Name 'Description') -and $ParameterJsonObject.Description)
+            {
+                $ParameterDescription = $ParameterJsonObject.Description
+            }
+
+            $ParameterDetails['Name'] = $parameterName
+            $ParameterDetails['Type'] = $paramType
+            $ParameterDetails['ValidateSet'] = $ValidateSetString
+            $ParameterDetails['Mandatory'] = $IsParamMandatory
+            $ParameterDetails['Description'] = $ParameterDescription
+
+            if($paramType)
+            {
+                $ParametersTable[$parameterName] = $ParameterDetails
+            }
+        }
+    }# $parametersSpec
+
+    $Unexpanded_AllOf_DefinitionNames = $AllOf_DefinitionNames
+    $Unexpanded_x_ms_client_flatten_DefinitionNames = $x_ms_Client_flatten_DefinitionNames
+    $ExpandedParameters = (-not $Unexpanded_AllOf_DefinitionNames -and -not $Unexpanded_x_ms_client_flatten_DefinitionNames)
+
+    $FunctionDetails = @{}
+    if($DefinitionFunctionsDetails.ContainsKey($Name))
+    {
+        $FunctionDetails = $DefinitionFunctionsDetails[$Name]
+    }
+
+    $FunctionDetails['Name'] = $Name
+    $FunctionDetails['Description'] = $FunctionDescription
+    $FunctionDetails['ParametersTable'] = $ParametersTable
+    $FunctionDetails['x_ms_Client_flatten_DefinitionNames'] = $x_ms_Client_flatten_DefinitionNames
+    $FunctionDetails['AllOf_DefinitionNames'] = $AllOf_DefinitionNames
+    $FunctionDetails['Unexpanded_x_ms_client_flatten_DefinitionNames'] = $Unexpanded_x_ms_client_flatten_DefinitionNames
+    $FunctionDetails['Unexpanded_AllOf_DefinitionNames'] = $Unexpanded_AllOf_DefinitionNames
+    $FunctionDetails['ExpandedParameters'] = $ExpandedParameters
+
+    if(-not $FunctionDetails.ContainsKey('IsUsedAs_x_ms_client_flatten'))
+    {
+        $FunctionDetails['IsUsedAs_x_ms_client_flatten'] = $false
+    }
+
+    if(-not $FunctionDetails.ContainsKey('IsUsedAs_AllOf'))
+    {
+        $FunctionDetails['IsUsedAs_AllOf'] = $false
+    }
+
+    $DefinitionFunctionsDetails[$Name] = $FunctionDetails
+}
+
+<#
+.DESCRIPTION
+  Generates a cmdlet for the definition
+#>
+function New-SwaggerSpecDefinitionCommand
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]
+        $FunctionDetails,
+
+        [Parameter(Mandatory=$true)]
+        [string] 
+        $GeneratedCommandsPath,
+
+        [Parameter(Mandatory=$true)]
+        [string] 
+        $Namespace 
+    )
+
+    $helpDescStr = @'
+.DESCRIPTION
+    $description
+'@
+
+    $advFnSignature = @'
+<#
+$commandHelp
+$paramHelp
+#>
+function $commandName
+{
+   param($paramblock
+   )
+   $body
+}
+'@
+
+    $parameterDefString = @'
+    
+    [Parameter(Mandatory = $isParamMandatory)] $ValidateSetDefinition    
+    [$paramType]
+    $paramName,
+
+'@
+
+    $ValidateSetDefinitionString = @'
+
+    [ValidateSet($ValidateSetString)]
+'@
+
+    $helpParamStr = @'
+
+.PARAMETER $parameterName
+    $pDescription
+
+'@
+
+    $functionBodyStr = @'
+
+   `$Object = New-Object -TypeName $DefinitionTypeName
+
+   `$PSBoundParameters.Keys | ForEach-Object { 
+       `$Object.`$_ = `$PSBoundParameters[`$_]
+   }
+
+   if(Get-Member -InputObject `$Object -Name Validate -MemberType Method)
+   {
+       `$Object.Validate()
+   }
+
+   return `$Object
+'@
+ 
+    $commandName = "New-$($FunctionDetails.Name)Object"
+
+    $description = $FunctionDetails.description
+    $commandHelp = $executionContext.InvokeCommand.ExpandString($helpDescStr)
+
+    [string]$paramHelp = ""
+    $paramblock = ""
+    $body = ""
+    $DefinitionTypeNamePrefix = "$Namespace.Models."
+
+    $FunctionDetails.ParametersTable.Keys | ForEach-Object {
+        $ParameterDetails = $FunctionDetails.ParametersTable[$_]
+
+        $isParamMandatory = $ParameterDetails.Mandatory
+        $parameterName = $ParameterDetails.Name
+        $paramName = "`$$parameterName" 
+        $paramType = $ParameterDetails.Type
+
+        $ValidateSetDefinition = $null
+        if ($ParameterDetails.ValidateSet)
+        {
+            $ValidateSetString = $ParameterDetails.ValidateSet
+            $ValidateSetDefinition = $executionContext.InvokeCommand.ExpandString($ValidateSetDefinitionString)
+        }
+        $paramblock += $executionContext.InvokeCommand.ExpandString($parameterDefString)
+
+        $pDescription = $ParameterDetails.Description
+        $paramHelp += $executionContext.InvokeCommand.ExpandString($helpParamStr)
+    }
+
+    $paramblock = $paramBlock.TrimEnd().TrimEnd(",")
+
+    $DefinitionTypeName = $DefinitionTypeNamePrefix + $FunctionDetails.Name
+    $body = $executionContext.InvokeCommand.ExpandString($functionBodyStr)
+
+    $CommandString = $executionContext.InvokeCommand.ExpandString($advFnSignature)
+    Write-Verbose $CommandString
+
+    if(-not (Test-Path -Path $GeneratedCommandsPath -PathType Container)) {
+        $null = New-Item -Path $GeneratedCommandsPath -ItemType Directory
+    }
+
+    $CommandFilePath = Join-Path -Path $GeneratedCommandsPath -ChildPath "$CommandName.ps1"
+    Out-File -InputObject $CommandString -FilePath $CommandFilePath -Encoding ascii -Force -Confirm:$false -WhatIf:$false
+
+    return $CommandName
 }
 
 <#
 .DESCRIPTION
   Converts an operation id to a reasonably good cmdlet name
 #>
-function Get-SwaggerCommandName
+function Get-SwaggerPathCommandName
 {
     param(
         [Parameter(Mandatory=$true)]
@@ -301,7 +824,13 @@ function Get-SwaggerCommandName
                     Delete = 'Remove'
                     List   = 'GetAll'
                 }
-    $opIdValues = $opId.Split('_')
+    $opIdValues = $opId  -split "_",2
+    
+    # OperationId can be specified without '_' (Underscore), return the OperationId as command name
+    if(-not $opIdValues -or ($opIdValues.Count -ne 2)) {
+        return $opId
+    }
+
     $cmdNoun = $opIdValues[0]
     $cmdVerb = $opIdValues[1]
     if (-not (get-verb $cmdVerb))
@@ -340,7 +869,7 @@ function Get-SwaggerCommandName
     return "$cmdVerb-$cmdNoun"
 }
 
-function Get-SwaggerSpecDefinitionsAndParameters
+function Get-SwaggerSpecDefinitionAndParameter
 {
     param(
         [Parameter(Mandatory=$true)]
@@ -379,7 +908,7 @@ function Get-SwaggerSpecDefinitionsAndParameters
     $SwaggerSpecificationDetails['infoVersion'] = $infoVersion
     $SwaggerSpecificationDetails['infoTitle'] = $infoTitle
     $SwaggerSpecificationDetails['infoName'] = $infoName
-    $SwaggerSpecificationDetails['Version'] = ($infoVersion -split "-",4) -join '.' 
+    $SwaggerSpecificationDetails['Version'] = [Version](($infoVersion -split "-",4) -join '.')
     $NamespaceVersionSuffix = "v$(($infoVersion -split '-',4) -join '')"
     $SwaggerSpecificationDetails['Namespace'] = "Microsoft.PowerShell.$ModuleName.$NamespaceVersionSuffix"
     $SwaggerSpecificationDetails['ModuleName'] = $ModuleName
@@ -388,7 +917,7 @@ function Get-SwaggerSpecDefinitionsAndParameters
         # Get global parameters
         $globalParams = $SwaggerSpecJsonObject.parameters
         $globalParams.PSObject.Properties | ForEach-Object {
-            $name = Remove-SpecialCharecters -Name $_.name
+            $name = Get-PascalCasedString -Name $_.name
             $SwaggerSpecificationDetails[$name] = $globalParams.$name
         }
     }
@@ -407,7 +936,29 @@ function Get-SwaggerSpecDefinitionsAndParameters
     return $SwaggerSpecificationDetails
 }
 
-function Remove-SpecialCharecters
+function Get-PascalCasedString {
+    param([string] $Name)
+
+    if($Name) {
+        $Name = Remove-SpecialCharecter -Name $Name
+        $startIndex = 0
+        $subStringLength = 1
+
+        # Convert the two letter abbreviations to upper case.
+        # Example: vmName --> VMName
+        if($Name.Length -gt 2) {
+            $thirdCharString = $Name.substring(2, 1)
+            if($thirdCharString.ToUpper() -ceq $thirdCharString) {
+                $subStringLength = 2
+            }
+        }
+
+        return $($Name.substring($startIndex, $subStringLength)).ToUpper() + $Name.substring($subStringLength)
+    }
+
+}
+
+function Remove-SpecialCharecter
 {
     param([string] $Name)
 
@@ -459,7 +1010,7 @@ function ConvertTo-CsharpCode
 
     Write-Verbose "Generating CSharp Code using AutoRest"
 
-    $autoRestExePath = get-command autorest.exe | % source
+    $autoRestExePath = get-command autorest.exe | ForEach-Object source
     if (-not $autoRestExePath)
     {
         throw "Unable to find AutoRest.exe in PATH environment. Ensure the PATH is updated."
@@ -469,16 +1020,15 @@ function ConvertTo-CsharpCode
     $outAssembly = join-path $outputDirectory "$Namespace.dll"
     $net45Dir = join-path $outputDirectory "Net45"
     $generatedCSharpPath = Join-Path $outputDirectory "Generated.Csharp"
-    $moduleManifestFile = (join-path $outputDirectory $ModuleName) + ".psd1"
 
     if (Test-Path $outAssembly)
     {
-        del $outAssembly -Force
+        Remove-Item -Path $outAssembly -Force
     }
 
     if (Test-Path $net45Dir)
     {
-        del $net45Dir -Force -Recurse
+        Remove-Item -Path $net45Dir -Force -Recurse
     }
 
     $codeGenerator = "CSharp"
@@ -498,7 +1048,7 @@ function ConvertTo-CsharpCode
         $refassemlbiles += "$PSScriptRoot\Generated.Azure.Common.Helpers\Net45\Microsoft.Rest.ClientRuntime.Azure.dll"
     }
 
-    & $autoRestExePath -AddCredentials -input $SwaggerSpecPath -CodeGenerator $codeGenerator -OutputDirectory $generatedCSharpPath -NameSpace $Namespace
+    $null = & $autoRestExePath -AddCredentials -input $SwaggerSpecPath -CodeGenerator $codeGenerator -OutputDirectory $generatedCSharpPath -NameSpace $Namespace
     if ($LastExitCode)
     {
         throw "AutoRest resulted in an error"
@@ -506,7 +1056,7 @@ function ConvertTo-CsharpCode
 
     Write-Verbose "Generating assembly from the CSharp code"
 
-    $srcContent = dir $generatedCSharpPath  -Filter *.cs -Recurse -Exclude Program.cs,TemporaryGeneratedFile* | ? DirectoryName -notlike '*Azure.Csharp.Generated*' | % { "// File $($_.FullName)"; get-content $_.FullName }
+    $srcContent = Get-ChildItem -Path $generatedCSharpPath  -Filter *.cs -Recurse -Exclude Program.cs,TemporaryGeneratedFile* | Where-Object DirectoryName -notlike '*Azure.Csharp.Generated*' | ForEach-Object { "// File $($_.FullName)"; get-content $_.FullName }
     $oneSrc = $srcContent -join "`n"
 
     Add-Type -TypeDefinition $oneSrc -ReferencedAssemblies $refassemlbiles -OutputAssembly $outAssembly
@@ -522,7 +1072,12 @@ function New-ModuleManifestUtility
 {
     param(
         [Parameter(Mandatory = $true)]
-        [string] $Path,
+        [string]
+        $Path,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]
+        $FunctionsToExport,
 
         [Parameter(Mandatory = $true)]        
         [PSCustomObject]
@@ -534,7 +1089,7 @@ function New-ModuleManifestUtility
                        -RequiredModules @('Generated.Azure.Common.Helpers') `
                        -RequiredAssemblies @("$($SwaggerSpecDefinitionsAndParameters['Namespace']).dll") `
                        -RootModule "$($SwaggerSpecDefinitionsAndParameters['ModuleName']).psm1" `
-                       -FunctionsToExport '*'
+                       -FunctionsToExport $FunctionsToExport
 }
 
 # Utility to throw an errorrecord

--- a/README.md
+++ b/README.md
@@ -17,38 +17,33 @@ Export-CommandFromSwagger -SwaggerSpecUri <uri> -Path <string> -ModuleName <stri
 
 ## Usage
 
-Note: Please run this steps on a Windows 10 Anniversary Update or Windows Server 2016 RTM and above.
+**Note**: Please run this steps on a Windows 10 Anniversary Update or Windows Server 2016 RTM and above.
 
 1. Git clone this repository.
-
-
-```code
-git clone https://github.com/PowerShell/PSSwagger.git
-```
+  ```code
+  git clone https://github.com/PowerShell/PSSwagger.git
+  ```
 
 2. Ensure you AutoRest version 0.16.0 installed
+  ```powershell
+  Install-Package -Name AutoRest -Source https://www.nuget.org/api/v2 -RequiredVersion 0.16.0 -Scope CurrentUser
+  ```   
 
-```powershell
-Install-Package -Name AutoRest -Source https://www.nuget.org/api/v2 -RequiredVersion 0.16.0 -Scope CurrentUser
-```
-   
 3. Ensure AutoRest.exe is in $env:Path
+  ```powershell
+  $env:path += ";$env:localappdata\PackageManagement\NuGet\Packages\AutoRest.0.16.0\tools"
+  ```
 
-```powershell
-$env:path += ";$env:localappdata\PackageManagement\NuGet\Packages\AutoRest.0.16.0\tools"
-```
-
-4. Run the following in a PowerShell console from the directory where you cloned PSSwagger in:
-
-```powershell
-Import-Module .\PSSwagger\PSSwagger.psd1
-$param = @{
+4. Run the following in a PowerShell console from the directory where you cloned PSSwagger in
+  ```powershell
+  Import-Module .\PSSwagger\PSSwagger.psd1
+  $param = @{
     SwaggerSpecUri = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-batch/2015-12-01/swagger/BatchManagement.json'
     Path           = 'C:\Temp\generatedmodule\'
     ModuleName     = 'Generated.Azure.BatchManagement'
-}
-Export-CommandFromSwagger @param
-```
+  }
+  Export-CommandFromSwagger @param
+  ```
 
 After step 4, the module will be in `C:\Temp\GeneratedModule\Generated.Azure.BatchManagement ($param.Path)` folder.
 


### PR DESCRIPTION
- Made changes to convert the parameter and cmdlet names into PascalCased strings.
- Azure.Network: Enabled a function generation scenario when OperationId doesnt contain '_' Underscore
- Added Warning and Verbose messages in the generated command for resource provisioning state to ensure that user waits for successful provisioning state before using that resource in next operations.
- Incorporated few PowerShell best practices like 'no alias usage', 'no plural command noun' and 'unused variables'
- Redirected the output of AutoRest.exe to not include in the command output.
- Added support for generating the proper parameter type names for both basic types and reference based parameter types.
- Added support for creating the generated module with version folder on PS 5.0.0 or newer.
- Made required changes to generate a separate script file for each generated commands for Swagger spec paths to <ModuleBase>/Generated.PowerShell.Commands/SwaggerPathCommands location.
- Updated the RootModule file to have below script code.

    Microsoft.PowerShell.Core\Set-StrictMode -Version Latest

    Get-ChildItem -Path $PSScriptRoot\Generated.PowerShell.Commands -Recurse -Filter *.ps1 -File | ForEach-Object { . $_.FullName}

- Also added the required logic to get the complete list of generated function names as FunctionsToExport in the module manifest file.
- Added Command generation logic for the Swagger Definitions including all supported Types, Arrays, Dictioneries, ValidateSet and Mandatory properties.
- Added support for x-ms-enum declarations in definitions. Added duplicate parameter detection logic for AllOf and x_ms_client_flatten definitions.
- Added support for generating Switch parameter type for Boolean type from Swagger Spec.
- Updated Readme.md