### PR TITLE
Add support for OMS ServiceMap Swagger spec.

### DIFF
--- a/PSSwagger/PSSwagger.Resources.psd1
+++ b/PSSwagger/PSSwagger.Resources.psd1
@@ -22,7 +22,7 @@ ConvertFrom-StringData @'
     UnableToGenerateAssembly=Unable to generate '{0}' assembly
     InvalidSwaggerSpecification=Invalid Swagger specification file. Info section doesn't exists.
     SwaggerSpecPathNotExist=Swagger file $SwaggerSpecPath does not exist. Check the path
-    SamePropertyName=Same property name should not be defined in a definition with AllOf inheritance.
+    SamePropertyName=Same property name '{0}' is defined in a definition '{1}' with AllOf inheritance.
     DataTypeNotImplemented=Please get an implementation of '{0}' for '{1}'
     AutoRestNotInPath=Unable to find AutoRest.exe in PATH environment. Ensure the PATH is updated.
     AutoRestError=AutoRest resulted in an error

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -24,13 +24,9 @@ function Get-SwaggerSpecPathInfo
         [PSCustomObject] 
         $PathFunctionDetails,
 
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $Info,
-        
         [Parameter(Mandatory = $true)]
         [hashTable]
-        $DefinitionList,
+        $swaggerDict,
 
         [Parameter(Mandatory = $true)]
         [hashtable]
@@ -38,11 +34,7 @@ function Get-SwaggerSpecPathInfo
 
         [Parameter(Mandatory = $true)]
         [hashtable]
-        $DefinitionFunctionsDetails,
-
-        [Parameter(Mandatory=$true)]
-        [PSCustomObject]
-        $SwaggerSpecDefinitionsAndParameters
+        $DefinitionFunctionsDetails
     )
 
     Get-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
@@ -55,7 +47,9 @@ function Get-SwaggerSpecPathInfo
             $FunctionDescription = $_.value.description 
         }
         
-        $paramInfo = Get-PathParamInfo -JsonPathItemObject $_.value -Info $Info -DefinitionFunctionsDetails $DefinitionFunctionsDetails
+        $paramInfo = Get-PathParamInfo -JsonPathItemObject $_.value `
+                                       -SwaggerDict $swaggerDict `
+                                       -DefinitionFunctionsDetails $DefinitionFunctionsDetails
 
         $responses = ""
         if((Get-Member -InputObject $_.value -Name 'responses') -and $_.value.responses) {
@@ -80,13 +74,11 @@ function Get-SwaggerSpecPathInfo
 
         $functionBodyParams = @{
             Responses = $responses
-            Info = $Info
-            DefinitionList = $DefinitionList
             operationId = $operationId
             RequiredParamList = $FunctionDetails['RequiredParamList']
             OptionalParamList = $FunctionDetails['OptionalParamList']
+            SwaggerDict = $SwaggerDict
             SwaggerMetaDict = $SwaggerMetaDict
-            SwaggerSpecDefinitionsAndParameters = $SwaggerSpecDefinitionsAndParameters
         }
 
         $bodyObject = Get-PathFunctionBody @functionBodyParams


### PR DESCRIPTION
- Added support for global parameters with x-ms-parameter-location: method.
- Added support for nested properties in definition properties.
- Removed Get-SwaggerSpecDefinitionAndParameter function and its usage as $swaggerDict has the required information.
- Definitions with Zero parameter count are ignored in generating the New-<DefinitionName>Object and corresponding Format file creation too.