### PR TITLE
Generate cmdlet name with singularized noun using PluralizationService on FullClr

### DIFF
--- a/PSSwagger/Definitions.psm1
+++ b/PSSwagger/Definitions.psm1
@@ -608,7 +608,6 @@ function New-SwaggerDefinitionFormatFile
     $TableColumnHeaders = $null
     $TableColumnItems = $TableColumnItemsList -join "`r`n"
     $FormatViewDefinition = $FormatViewDefinitionStr -f ($ViewName, $ViewTypeName, $TableColumnHeaders, $TableColumnItems)
-    Write-Verbose -Message $FormatViewDefinition
 
     if(-not (Test-Path -Path $FormatFilesPath -PathType Container))
     {

--- a/PSSwagger/PSSwagger.Constants.ps1
+++ b/PSSwagger/PSSwagger.Constants.ps1
@@ -6,6 +6,11 @@
 #
 #########################################################################################
 
+$script:IsWindows = (-not (Get-Variable -Name IsWindows -ErrorAction Ignore)) -or $IsWindows
+$script:IsLinux = (Get-Variable -Name IsLinux -ErrorAction Ignore) -and $IsLinux
+$script:IsOSX = (Get-Variable -Name IsOSX -ErrorAction Ignore) -and $IsOSX
+$script:IsCoreCLR = (Get-Variable -Name IsCoreCLR -ErrorAction Ignore) -and $IsCoreCLR
+
 $helpDescStr = @'
 .DESCRIPTION
     $description

--- a/PSSwagger/PSSwagger.Resources.psd1
+++ b/PSSwagger/PSSwagger.Resources.psd1
@@ -36,5 +36,6 @@ ConvertFrom-StringData @'
     ParameterSetNotAllowed=The '{0}' parameter is not allowed when '{1}' is specified.
     AssemblyCompilationResult=Result of assembly compilation: {0}
     CmdletHasAmbiguousParameterSets=The generated cmdlet '{0}' contains ambiguous parameter sets. This is due to automatic merging of two or more similar paths.
+    PathNotFound=Cannot find the path '{0}' because it does not exist.
 ###PSLOC
 '@

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -215,7 +215,7 @@ function New-SwaggerPath
         $defaultParameterSet = $nonUniqueParameterSets | Sort-Object -Property Priority | Select-Object -First 1
         $DefaultParameterSetName = $defaultParameterSet.OperationId
         $description = $defaultParameterSet.Description
-        Write-Warning -Message ($LocalizedDataCmdletHasAmbiguousParameterSets -f ($commandName))
+        Write-Warning -Message ($LocalizedData.CmdletHasAmbiguousParameterSets -f ($commandName))
     } elseif ($nonUniqueParameterSets.Length -eq 1) {
         # If there's only one non-unique, we can prevent errors by making this the default
         $DefaultParameterSetName = $nonUniqueParameterSets[0].OperationId

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -176,7 +176,7 @@ Describe "Get/List tests" -Tag ScenarioTest {
         }
 
         It "List has no parameters and no corresponding Get" {
-            $results = Get-Tags
+            $results = Get-Tag
             $results.Length | should be 2
         }
     }


### PR DESCRIPTION
Additional changes:
- Added resolve and validation logic for Path parameter. Which will also handle '.' and '..' as values for -Path parameter.
- Added required changes to remove whitespaces in InfoName property of Info object.

Resolves #133, #131, #126