### PR TITLE
Add -DefaultCommandPrefix parameter on New-PSSwaggerModule cmdlet

### DIFF
--- a/Demos/Demo-AzureRMResourceCommands.ps1
+++ b/Demos/Demo-AzureRMResourceCommands.ps1
@@ -28,7 +28,7 @@ $param = @{
 
 # AzureRM.Resources
 $param['SwaggerSpecUri'] = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-resources/resources/2015-11-01/swagger/resources.json'
-$param['ModuleName']     = 'Generated.AzureRM.Resources'
+$param['Name']           = 'Generated.AzureRM.Resources'
 New-PSSwaggerModule @param
 #endregion Generate AzureRM commands
 

--- a/Demos/Demo-GeneratedAzureRMCommands.ps1
+++ b/Demos/Demo-GeneratedAzureRMCommands.ps1
@@ -40,22 +40,22 @@ $param = @{
 
 # AzureRM.Resources
 $param['SwaggerSpecUri'] = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-resources/resources/2015-11-01/swagger/resources.json'
-$param['ModuleName']     = 'Generated.AzureRM.Resources'
+$param['Name']           = 'Generated.AzureRM.Resources'
 New-PSSwaggerModule @param
 
 # AzureRM.Storage
 $param['SwaggerSpecUri'] = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-storage/2015-06-15/swagger/storage.json'
-$param['ModuleName']     = 'Generated.AzureRM.Storage'
+$param['Name']           = 'Generated.AzureRM.Storage'
 New-PSSwaggerModule @param
 
 # AzureRM.Network
 $param['SwaggerSpecUri'] = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-network/2015-06-15/swagger/network.json'
-$param['ModuleName']     = 'Generated.AzureRM.Network'
+$param['Name']           = 'Generated.AzureRM.Network'
 New-PSSwaggerModule @param
 
 # AzureRM.Compute
 $param['SwaggerSpecUri'] = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/2015-06-15/swagger/compute.json'
-$param['ModuleName']     = 'Generated.AzureRM.Compute'
+$param['Name']           = 'Generated.AzureRM.Compute'
 New-PSSwaggerModule @param
 
 #endregion Generate AzureRM commands

--- a/Demos/Demo-GeneratedAzureStackRMCommands.ps1
+++ b/Demos/Demo-GeneratedAzureStackRMCommands.ps1
@@ -35,7 +35,7 @@ $ModuleName = 'Generated.AzureStackRM.FabricResourceProvider'
 $param = @{
     SwaggerSpecUri  = 'C:\code\swaggerrelated\JsonFiles\SwaggerTransformed.json'
     Path            = $TargetPath
-    ModuleName      = $ModuleName
+    Name            = $ModuleName
     UseAzureCsharpGenerator = $false
 }
 New-PSSwaggerModule @param

--- a/PSSwagger/Definitions.psm1
+++ b/PSSwagger/Definitions.psm1
@@ -361,7 +361,7 @@ function New-SwaggerDefinitionCommand
         $SwaggerMetaDict,
 
         [Parameter(Mandatory = $true)]
-        [String]
+        [string]
         $NameSpace
     )
 
@@ -548,7 +548,6 @@ function New-SwaggerSpecDefinitionCommand
     $body = $executionContext.InvokeCommand.ExpandString($createObjectStr)
 
     $CommandString = $executionContext.InvokeCommand.ExpandString($advFnSignatureForDefintion)
-    Write-Verbose -Message $CommandString
 
     if(-not (Test-Path -Path $GeneratedCommandsPath -PathType Container)) {
         $null = New-Item -Path $GeneratedCommandsPath -ItemType Directory
@@ -556,6 +555,8 @@ function New-SwaggerSpecDefinitionCommand
 
     $CommandFilePath = Join-Path -Path $GeneratedCommandsPath -ChildPath "$CommandName.ps1"
     Out-File -InputObject $CommandString -FilePath $CommandFilePath -Encoding ascii -Force -Confirm:$false -WhatIf:$false
+
+    Write-Verbose -Message ($LocalizedData.GeneratedDefinitionCommand -f ($commandName, $FunctionDetails.Name))
 
     return $CommandName
 }
@@ -615,4 +616,5 @@ function New-SwaggerDefinitionFormatFile
     }
     $FormatFilePath = Join-Path -Path $FormatFilesPath -ChildPath "$($FunctionDetails.Name).ps1xml"
     Out-File -InputObject $FormatViewDefinition -FilePath $FormatFilePath -Encoding ascii -Force -Confirm:$false -WhatIf:$false
+    Write-Verbose -Message ($LocalizedData.GeneratedFormatFile -f $FunctionDetails.Name)
 }

--- a/PSSwagger/PSSwagger.Constants.ps1
+++ b/PSSwagger/PSSwagger.Constants.ps1
@@ -28,7 +28,7 @@ $parameterDefString = @'
 
 $RootModuleContents = @'
 Microsoft.PowerShell.Core\Set-StrictMode -Version Latest
-Microsoft.PowerShell.Utility\Import-LocalizedData  LocalizedData -filename $ModuleName.Resources.psd1
+Microsoft.PowerShell.Utility\Import-LocalizedData  LocalizedData -filename $Name.Resources.psd1
 . (Join-Path -Path "`$PSScriptRoot" -ChildPath "Utils.ps1")
 
 if ('Core' -eq (Get-PSEdition)) {

--- a/PSSwagger/PSSwagger.Resources.psd1
+++ b/PSSwagger/PSSwagger.Resources.psd1
@@ -37,5 +37,8 @@ ConvertFrom-StringData @'
     AssemblyCompilationResult=Result of assembly compilation: {0}
     CmdletHasAmbiguousParameterSets=The generated cmdlet '{0}' contains ambiguous parameter sets. This is due to automatic merging of two or more similar paths.
     PathNotFound=Cannot find the path '{0}' because it does not exist.
+    GeneratedPathCommand=Generated path command '{0}'.
+    GeneratedDefinitionCommand=Generated command '{0}' for the definition name '{1}'.
+    GeneratedFormatFile=Generated output format file for the definition name '{0}'.
 ###PSLOC
 '@

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -283,9 +283,10 @@ function New-SwaggerPath
         $null = New-Item -Path $GeneratedCommandsPath -ItemType Directory
     }
 
-    Write-Verbose -Message $CommandString
-
     $CommandFilePath = Join-Path -Path $GeneratedCommandsPath -ChildPath "$commandName.ps1"
     Out-File -InputObject $CommandString -FilePath $CommandFilePath -Encoding ascii -Force -Confirm:$false -WhatIf:$false
+
+    Write-Verbose -Message ($LocalizedData.GeneratedPathCommand -f $commandName)
+
     return $commandName
 }

--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -29,7 +29,7 @@ function ConvertTo-SwaggerDictionary {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [String]
+        [string]
         $SwaggerSpecPath,
 
         [Parameter(Mandatory=$true)]
@@ -38,7 +38,11 @@ function ConvertTo-SwaggerDictionary {
 
         [Parameter(Mandatory=$true)]
         [Version]
-        $ModuleVersion
+        $ModuleVersion,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $DefaultCommandPrefix
     )
     
     Get-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
@@ -50,6 +54,7 @@ function ConvertTo-SwaggerDictionary {
         Throw $LocalizedData.InvalidSwaggerSpecification
     }
     $swaggerDict['Info'] = Get-SwaggerInfo -Info $swaggerObject.info -ModuleName $ModuleName -ModuleVersion $ModuleVersion
+    $swaggerDict['Info']['DefaultCommandPrefix'] = $DefaultCommandPrefix
 
     $swaggerParameters = $null
     if(Get-Member -InputObject $swaggerObject -Name 'parameters') {
@@ -323,11 +328,11 @@ function Get-ParamType
         $ParameterJsonObject,
 
         [Parameter(Mandatory=$true)]
-        [String]
+        [string]
         $NameSpace,
 
         [Parameter(Mandatory=$true)]
-        [String]
+        [string]
         [AllowEmptyString()]
         $ParameterName,
 
@@ -508,7 +513,7 @@ function Get-PathCommandName
     param
     (
         [Parameter(Mandatory=$true)]
-        [String]
+        [string]
         $OperationId
     )
 
@@ -552,7 +557,7 @@ function Get-PathCommandName
             # This condition happens when there aren't any suffixes
             $cmdVerb = $cmdVerbMap[$cmdVerb] -Split ',' | ForEach-Object { if($_.Trim()){ $_.Trim() } }
             $cmdVerb | ForEach-Object {
-                $message = $LocalizedData.ReplacedVerb -f ($_, $cmdVerb)
+                $message = $LocalizedData.ReplacedVerb -f ($_, ($cmdVerb -join ','))
                 Write-Verbose -Message $message
             }
         }
@@ -801,7 +806,7 @@ function Get-OutputType
         $Schema,
 
         [Parameter(Mandatory=$true)]
-        [String]
+        [string]
         $NameSpace, 
 
         [Parameter(Mandatory=$true)]
@@ -887,7 +892,7 @@ function Get-Response
         $Responses,
         
         [Parameter(Mandatory=$true)]
-        [String]
+        [string]
         $NameSpace, 
 
         [Parameter(Mandatory=$true)]        

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ Tool to generate PowerShell Cmdlets using Swagger based specifications
 
 ## Syntax
 
-New-PSSwaggerModule -SwaggerSpecPath <string> -Path <string> -ModuleName <string> [-Version <version>] [-UseAzureCsharpGenerator] [-SkipAssemblyGeneration] [-PowerShellCorePath <string>] [-IncludeCoreFxAssembly] [<CommonParameters>]
+New-PSSwaggerModule -SwaggerSpecPath <string> -Path <string> -Name <string> [-Version <version>] [-UseAzureCsharpGenerator] [-SkipAssemblyGeneration] [-PowerShellCorePath <string>] [-IncludeCoreFxAssembly] [-DefaultCommandPrefix <string>] [<CommonParameters>]
 
-New-PSSwaggerModule -SwaggerSpecUri <uri> -Path <string> -ModuleName <string> [-Version <version>] [-UseAzureCsharpGenerator] [-SkipAssemblyGeneration] [-PowerShellCorePath <string>] [-IncludeCoreFxAssembly] [<CommonParameters>]
-
+New-PSSwaggerModule -SwaggerSpecUri <uri> -Path <string> -Name <string> [-Version <version>] [-UseAzureCsharpGenerator] [-SkipAssemblyGeneration] [-PowerShellCorePath <string>] [-IncludeCoreFxAssembly] [-DefaultCommandPrefix <string>] [<CommonParameters>]
 | Parameter       | Description                           |
 | ----------------| ------------------------------------- |
 | SwaggerSpecPath | Full Path to a Swagger based JSON spec|
 | Path            | Full Path to a folder where the commands/modules are exported to |
-| ModuleName      | Name of the module to be generated. A folder with this name will be created in the location specified by Path parameter |
+| Name            | Name of the module to be generated. A folder with this name will be created in the location specified by Path parameter |
 | Version  | Version of the module to be generated. Default value is '0.0.1' |
 | SwaggerSpecUri  | URI to the swagger spec |
+| DefaultCommandPrefix  | Prefix value to be prepended to cmdlet noun or to cmdlet name without verb. |
 | SkipAssemblyGeneration      | Skip compiling the generated module's C# assembly during generation of module (including CoreFX, even if specified) |
 | PowerShellCorePath      | Path to PowerShell.exe for PowerShell Core. Only required if not installed via MSI in the default path |
 | IncludeCoreFxAssembly      | Switch to additionally compile the module's binary component for core CLR |
@@ -53,8 +53,8 @@ New-PSSwaggerModule -SwaggerSpecUri <uri> -Path <string> -ModuleName <string> [-
   Import-Module .\PSSwagger\PSSwagger.psd1
   $param = @{
     SwaggerSpecUri = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-batch/2015-12-01/swagger/BatchManagement.json'
-    Path           = 'C:\Temp\generatedmodule\'
-    ModuleName     = 'Generated.AzureRM.BatchManagement'
+    Path           = 'C:\GeneratedModules\'
+    Name           = 'AzBatchManagement'
     UseAzureCsharpGenerator = $true
   }
   New-PSSwaggerModule @param
@@ -66,8 +66,8 @@ Before importing that module and using it, you need to import `Generated.Azure.C
     
 ```powershell
 Import-Module .\PSSwagger\Generated.Azure.Common.Helpers
-Import-Module "$($param.Path)\$($param.ModuleName)"
-Get-Command -Module $param.ModuleName
+Import-Module "$($param.Path)\$($param.Name)"
+Get-Command -Module $param.Name
 ```
 
 ## Dynamic generation of C# assembly

--- a/Tests/TestUtilities.psm1
+++ b/Tests/TestUtilities.psm1
@@ -82,7 +82,7 @@ function Initialize-Test {
     }
 
     Write-Verbose "Generating module"
-    New-PSSwaggerModule -SwaggerSpecPath (Join-Path -Path $testCaseDataLocation -ChildPath $TestSpecFileName) -Path "$generatedModulesPath" -ModuleName $GeneratedModuleName -Verbose -SkipAssemblyGeneration
+    New-PSSwaggerModule -SwaggerSpecPath (Join-Path -Path $testCaseDataLocation -ChildPath $TestSpecFileName) -Path "$generatedModulesPath" -Name $GeneratedModuleName -Verbose -SkipAssemblyGeneration
     if (-not $?) {
         throw 'Failed to generate module. Expected: Success'
     }


### PR DESCRIPTION
Resolves #138 and #134
- Added -DefaultCommandPrefix parameter on New-PSSwaggerModule cmdlet for specifying cmdlet noun prefix.
- Renamed -ModuleName parameter on New-PSSwaggerModule to -Name as this cmdlet noun conveys module is being generated.
- Added few verbose messages.