### PR TITLE
Extract Description, Author, CopyRight, ProjectUri and LicenseUri from Swagger spec

### DIFF
--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -488,6 +488,9 @@ function New-ModuleManifestUtility
     $NewModuleManifest_params = @{
         Path = "$(Join-Path -Path $Path -ChildPath $Info.ModuleName).psd1"
         ModuleVersion = $Info.Version
+        Description = $Info.Description
+        CopyRight = $info.LicenseName
+        Author = $info.ContactEmail
         RequiredModules = @('Generated.Azure.Common.Helpers')
         RootModule = "$($Info.ModuleName).psm1"
         FormatsToProcess = $FormatsToProcess
@@ -496,6 +499,20 @@ function New-ModuleManifestUtility
     if($Info.DefaultCommandPrefix)
     {
         $NewModuleManifest_params['DefaultCommandPrefix'] = $Info.DefaultCommandPrefix
+    }
+
+    if($PSVersionTable.PSVersion -ge '5.0.0')
+    {
+        # Below parameters are not available on PS 3 and 4 versions.
+        if($Info.ProjectUri)
+        {
+            $NewModuleManifest_params['ProjectUri'] = $Info.ProjectUri
+        }
+
+        if($Info.LicenseUri)
+        {
+            $NewModuleManifest_params['LicenseUri'] = $Info.LicenseUri
+        }
     }
 
     New-ModuleManifest @NewModuleManifest_params

--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -114,6 +114,57 @@ function Get-SwaggerInfo {
         $infoName = ($infoTitle -replace '[^a-zA-Z0-9_]','')
     }
 
+    $Description = $null
+    if((Get-Member -InputObject $Info -Name 'Description') -and $Info.Description) { 
+        $Description = $Info.Description
+    }
+
+    $ProjectUri = $null
+    $ContactEmail = $null
+    $ContactName = $null
+    if(Get-Member -InputObject $Info -Name 'Contact')
+    {
+        # The identifying name of the contact person/organization.
+        if((Get-Member -InputObject $Info.Contact -Name 'Name') -and
+            $Info.Contact.Name)
+        { 
+            $ContactName = $Info.Contact.Name
+        }
+
+        # The URL pointing to the contact information. MUST be in the format of a URL.
+        if((Get-Member -InputObject $Info.Contact -Name 'Url') -and
+            $Info.Contact.Url)
+        { 
+            $ProjectUri = $Info.Contact.Url
+        }
+
+        # The email address of the contact person/organization. MUST be in the format of an email address.
+        if((Get-Member -InputObject $Info.Contact -Name 'Email') -and
+            $Info.Contact.Email)
+        { 
+            $ContactEmail = $Info.Contact.Email
+        }        
+    }
+
+    $LicenseUri = $null
+    $LicenseName = $null
+    if(Get-Member -InputObject $Info -Name 'License')
+    {
+        # A URL to the license used for the API. MUST be in the format of a URL.
+        if((Get-Member -InputObject $Info.License -Name 'Url') -and
+          $Info.License.Url)
+        { 
+            $LicenseUri = $Info.License.Url
+        }
+
+        # License name.
+        if((Get-Member -InputObject $Info.License -Name 'Name') -and
+          $Info.License.Name)
+        { 
+            $LicenseName = $Info.License.Name
+        }
+    }
+
     $NamespaceVersionSuffix = "v$("$ModuleVersion" -replace '\.','')"
 
     return @{
@@ -123,6 +174,12 @@ function Get-SwaggerInfo {
         Version = $ModuleVersion
         NameSpace = "Microsoft.PowerShell.$ModuleName.$NamespaceVersionSuffix"
         ModuleName = $ModuleName
+        Description = $Description
+        ContactName = $ContactName
+        ContactEmail = $ContactEmail
+        ProjectUri = $ProjectUri
+        LicenseUri = $LicenseUri
+        LicenseName = $LicenseName
     }
 }
 

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -40,6 +40,19 @@ Describe "Basic API" -Tag ScenarioTest {
             Get-Cupcake -Flavor "chocolate"
             New-Cupcake -Flavor "vanilla"
         }
+
+        It "Module medatata test" {
+            $ModuleInfo = Get-Module 'Generated.Basic.Module'
+            $ModuleInfo.Description | Should be 'Very basic API for PSSwagger testing.'
+            $ModuleInfo.Author | Should be 'support@swagger.io'
+            $ModuleInfo.CopyRight | Should be 'Apache 2.0'
+
+            if($PSVersionTable.PSVersion -ge '5.0.0')
+            {
+                $ModuleInfo.PrivateData.PSData.LicenseUri | Should be 'http://www.apache.org/licenses/LICENSE-2.0.html'
+                $ModuleInfo.PrivateData.PSData.ProjectUri | Should be 'http://www.swagger.io/support'
+            }
+        }
     }
 
     AfterAll {

--- a/tests/data/PsSwaggerTestBasic/PsSwaggerTestBasicSpec.json
+++ b/tests/data/PsSwaggerTestBasic/PsSwaggerTestBasicSpec.json
@@ -3,7 +3,16 @@
     "info": {
         "title": "PsSwaggerTestBasic",
         "description": "Very basic API for PSSwagger testing.",
-        "version": "2017-01-01"
+        "version": "2017-01-01",
+        "contact":{
+            "name": "API Support",
+            "url": "http://www.swagger.io/support",
+            "email": "support@swagger.io"
+        },
+        "license":{
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        }
     },
     "host": "localhost:3000",
     "schemes": [


### PR DESCRIPTION
Added required code changes to extract the Description, Author, CopyRight, ProjectUri and LicenseUri module metadata properties from the Swagger document.
Resolves #66 and #65 .