### PR TITLE
Avoid using Keys, Count and Values properties on Hashtable in PowerShell Scripting

### DIFF
--- a/PSSwagger/PSSwagger.Constants.ps1
+++ b/PSSwagger/PSSwagger.Constants.ps1
@@ -214,7 +214,7 @@ Write-Verbose -Message "Waiting for the operation to complete."
         $ScriptBlockParameters = New-Object -TypeName 'System.Collections.Generic.Dictionary[string,object]'
         $ScriptBlockParameters['TaskResult'] = $TaskResult
         $ScriptBlockParameters['AsJob'] = $AsJob
-        $PSCommonParameters.Keys | ForEach-Object { $ScriptBlockParameters[$_] = $PSCommonParameters[$_] }
+        $PSCommonParameters.GetEnumerator() | ForEach-Object { $ScriptBlockParameters[$_.Name] = $_.Value }
 
         Invoke-SwaggerCommandUtility -ScriptBlock $PSSwaggerJobScriptBlock `
                                      -CallerPSBoundParameters $ScriptBlockParameters `
@@ -268,8 +268,8 @@ $createObjectStr = @'
 
     `$Object = New-Object -TypeName $DefinitionTypeName
 
-    `$PSBoundParameters.Keys | ForEach-Object { 
-        `$Object.`$_ = `$PSBoundParameters[`$_]
+    `$PSBoundParameters.GetEnumerator() | ForEach-Object { 
+        `$Object.`$(`$_.Key) = `$_.Value
     }
 
     if(Get-Member -InputObject `$Object -Name Validate -MemberType Method)
@@ -282,10 +282,10 @@ $createObjectStr = @'
 
 $ApiVersionStr = @'
 
-        if(Get-Member -InputObject $clientName -Name 'ApiVersion' -MemberType Property)
-        {
-            $clientName.ApiVersion = "$infoVersion"
-        }
+    if(Get-Member -InputObject $clientName -Name 'ApiVersion' -MemberType Property)
+    {
+        $clientName.ApiVersion = "$infoVersion"
+    }
 '@
 
 $GeneratedCommandsName = 'Generated.PowerShell.Commands'

--- a/PSSwagger/PSSwagger.Resources.psd1
+++ b/PSSwagger/PSSwagger.Resources.psd1
@@ -49,5 +49,6 @@ ConvertFrom-StringData @'
     ReferenceTypeDefaultValueNotSupported=PSSwagger doesn't support setting a reference-type default value. Parameter: '{0}', Parameter Type: '{1}', Cmdlet: '{2}'
     ResultCodeMetadataExtraction=Result of code metadata extraction: {0}
     MetadataExtractFailed=Module generation failed. If no error messages follow, check the output of code metadata extraction above
+    SuccessfullyGeneratedModule=Successfully generated module '{0}' at '{1}' for the specified Swagger specification.
 ###PSLOC
 '@

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -301,6 +301,8 @@ function New-PSSwaggerModule
                               -Info $swaggerDict['info']
 
     Copy-Item (Join-Path -Path "$PSScriptRoot" -ChildPath "Generated.Resources.psd1") (Join-Path -Path "$outputDirectory" -ChildPath "$Name.Resources.psd1") -Force
+
+    Write-Verbose -Message ($LocalizedData.SuccessfullyGeneratedModule -f $Name,$outputDirectory)
 }
 
 #region Module Generation Helpers

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -139,9 +139,8 @@ function New-SwaggerSpecPathCommand
     $fullModuleName = $Namespace + '.' + $modulePostfix
 
     $FunctionsToExport = @()
-    $PathFunctionDetails.Keys | ForEach-Object {
-        $FunctionDetails = $PathFunctionDetails[$_]
-        $FunctionsToExport += New-SwaggerPath -FunctionDetails $FunctionDetails `
+    $PathFunctionDetails.GetEnumerator() | ForEach-Object {
+        $FunctionsToExport += New-SwaggerPath -FunctionDetails $_.Value `
                                               -SwaggerMetaDict $SwaggerMetaDict `
                                               -SwaggerDict $SwaggerDict
     }
@@ -188,7 +187,8 @@ function New-SwaggerPath
     $parametersToAdd = @{}
     $parameterHitCount = @{}
     foreach ($parameterSetDetail in $parameterSetDetails) {
-        foreach ($parameterDetails in $parameterSetDetail.ParameterDetails.Values) {
+        $parameterSetDetail.ParameterDetails.GetEnumerator() | ForEach-Object {
+            $parameterDetails = $_.Value
             $parameterName = $parameterDetails.Name
             if($parameterDetails.IsParameter) {
                 if (-not $parameterHitCount.ContainsKey($parameterName)) {
@@ -218,7 +218,8 @@ function New-SwaggerPath
     $nonUniqueParameterSets = @()
     foreach ($parameterSetDetail in $parameterSetDetails) {
         $isUnique = $false
-        foreach ($parameterDetails in $parameterSetDetail.ParameterDetails.Values) {
+        $parameterSetDetail.ParameterDetails.GetEnumerator() | ForEach-Object {
+            $parameterDetails = $_.Value
             if ($parameterHitCount[$parameterDetails.Name] -eq 1) {
                 $isUnique = $true
                 break
@@ -249,7 +250,8 @@ function New-SwaggerPath
         $description = $defaultParameterSet.Description
     }
 
-    foreach ($parameterToAdd in $parametersToAdd.Values) {
+    $parametersToAdd.GetEnumerator() | ForEach-Object {
+        $parameterToAdd = $_.Value
         $parameterName = $parameterToAdd.Details.Name
         $AllParameterSetsString = ''
         foreach ($parameterSetInfo in $parameterToAdd.ParameterSetInfo) {
@@ -343,8 +345,8 @@ function Set-ExtendedCodeMetadata {
     $resultRecord.VerboseMessages += $LocalizedData.ExtractingMetadata
 
     $PathFunctionDetails = Import-CliXml -Path $CliXmlTmpPath
-    $PathFunctionDetails.Keys | ForEach-Object {
-        $FunctionDetails = $PathFunctionDetails[$_]
+    $PathFunctionDetails.GetEnumerator() | ForEach-Object {
+        $FunctionDetails = $_.Value
         $ParameterSetDetails = $FunctionDetails['ParameterSetDetails']
         foreach ($parameterSetDetail in $ParameterSetDetails) {
             $operationId = $parameterSetDetail.OperationId

--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -704,7 +704,7 @@ function Convert-ParamTable
 
     $requiredParamList = @()
     $optionalParamList = @()
-    $keyCount = $ParamTable.Keys.Count
+    $keyCount = Get-HashtableKeyCount -Hashtable $ParamTable
     if($keyCount)
     {
         # This foreach is required to get the parameters in sequential/expected order 

--- a/PSSwagger/Utilities.psm1
+++ b/PSSwagger/Utilities.psm1
@@ -29,6 +29,25 @@ function Get-PascalCasedString
 
 }
 
+<#
+.DESCRIPTION
+    Some hashtables can have 'Count' as a key value, 
+    in that case, $Hashtable.Count return the value rather than hashtable keys count in PowerShell.
+    This utility uses enumerator to count the number of keys in a hashtable.
+#>
+function Get-HashtableKeyCount
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]
+        $Hashtable
+    )
+
+    $KeyCount = 0
+    $Hashtable.GetEnumerator() | ForEach-Object { $KeyCount++ }    
+    return $KeyCount
+}
+
 function Remove-SpecialCharacter
 {
     param([string] $Name)
@@ -112,9 +131,9 @@ function Get-CallerPreference
         'PSDefaultParameterValues' = $null
     }
 
-    $Variables.keys | ForEach-Object {
-        $VariableName = $_
-        $VariableValue = $Variables[$_]
+    $Variables.GetEnumerator() | ForEach-Object {
+        $VariableName = $_.Name
+        $VariableValue = $_.Value
 
         if (-not $VariableValue -or
             -not $Cmdlet.MyInvocation.BoundParameters.ContainsKey($VariableValue))


### PR DESCRIPTION
Resolves #153.