### PR TITLE
Account for missing parameters that are not OData parameters

### DIFF
--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -83,7 +83,7 @@ function Get-SwaggerSpecPathInfo
 
             if ((Get-Member -InputObject $_.Value -Name 'x-ms-odata') -and $_.Value.'x-ms-odata') {
                 # Currently only the existence of this property is really important, but might as well save the value
-                $ParameterSetDetail.ODataDefinition = $_.Value.'x-ms-odata'
+                $ParameterSetDetail.'x-ms-odata' = $_.Value.'x-ms-odata'
             }
 
             # There's probably a better way to do this...
@@ -495,7 +495,7 @@ function Set-ExtendedCodeMetadata {
                 }
             }
 
-            if ($parameterSetDetail.ContainsKey('ODataDefinition') -and $parameterSetDetail.ODataDefinition) {
+            if ($parameterSetDetail.ContainsKey('x-ms-odata') -and $parameterSetDetail.'x-ms-odata') {
                 $paramObject.GetEnumerator() | ForEach-Object {
                     $paramDetail = $_.Value
 


### PR DESCRIPTION
Resolves #159 

Still issues with AzSearch module, but at least PSSwagger doesn't think the missing parameters are odata.