### PR TITLE
Support for composite swagger specs in PSSwagger

### DIFF
--- a/PSSwagger/PSSwagger.Resources.psd1
+++ b/PSSwagger/PSSwagger.Resources.psd1
@@ -28,7 +28,9 @@ ConvertFrom-StringData @'
     AutoRestError=AutoRest resulted in an error
     SwaggerParamsMissing=No parameters in the Swagger
     SwaggerDefinitionsMissing=No definitions in the Swagger
-    SwaggerPathsMissing=No paths in the Swagger
+    SwaggerPathsMissing=No paths found in the Swagger document '{0}'.
+    SkippingExistingParameter=Skipping an existing swagger parameter {0}.
+    SkippingExistingKeyFromSwaggerMultiItemObject=Skipping an existing key '{0}' from SwaggerMultiItemObject.
     FoundFileWithHash=Found file '{0}' with hash '{1}'
     FoundPowerShellCoreMsi=Found MSI installation of PowerShell Core of version '{0}'
     MustSpecifyPsCorePath=No installations of PowerShell Core could be found. Please provide -PowerShellCorePath to specify the location of PowerShell Core.
@@ -57,5 +59,7 @@ ConvertFrom-StringData @'
     FlatteningParameterType=Flattening parameter '{0}' of type '{1}'
     ParameterExpandedTo=Parameter '{0}' was expanded to parameter '{1}'
     DuplicateExpandedProperty=Duplicate expanded property name: '{0}'
+    InvalidPathParameterType=Extracted an invalid parameter type '{0}' for parameter '{1}' in path operation.
+    InvalidDefinitionParameterType=Extracted an invalid parameter type '{0}' for parameter '{1}' in definition '{2}'.
 ###PSLOC
 '@

--- a/Tests/data/CompositeSwaggerTest/composite-swagger.json
+++ b/Tests/data/CompositeSwaggerTest/composite-swagger.json
@@ -1,0 +1,10 @@
+{
+  "info": {
+    "title": "CompositeSwaggerClient",
+    "description": "Swagger description."
+  },
+  "documents": [
+    "./swagger-1.json",
+    "./swagger-2.json"
+  ]  
+}

--- a/Tests/data/CompositeSwaggerTest/swagger-1.json
+++ b/Tests/data/CompositeSwaggerTest/swagger-1.json
@@ -1,0 +1,180 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger 1",
+    "description": "Swagger 1 documentation.",
+    "version": "2014-04-01-preview",
+    "x-ms-code-generation-settings": {
+      "internalConstructors": false
+    }
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [ "application/json" ],
+  "consumes": [ "application/json" ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resource": {
+      "get": {
+        "operationId": "SimpleGet",
+        "summary": "Get product",
+        "description": "Operation description.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParamterer"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "tags": [
+          "Redis"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resources",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Resource_Create",
+        "summary": "Create product",
+        "description": "Operation description.",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Payload",
+            "required": true,
+            "schema": {"$ref": "#/definitions/Product"}
+          },
+          {
+            "name": "apiVersion",
+            "in": "path",
+            "description": "API ID.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Redis"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of caches"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Product": {
+      "description": "The product documentation.",
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles."
+        },
+        "Tags": {
+          "$ref": "#/definitions/Tags",
+          "description": "Tags are a list of key-value pairs that describe the resource. These tags can be used in viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key no greater than 128 characters and value no greater than 256 characters."
+        },
+        "startDate": {
+          "$ref": "#/definitions/date",
+          "description": "The RFC3339 full-date of the start of the period for which data is exported."
+        },
+        "endDate": {
+          "$ref": "#/definitions/date",
+          "description": "The RFC3339 full-date of the end of the period for which data is exported."
+        },
+        "IntParamName": {
+          "$ref": "#/definitions/IntTypeDef",
+          "description": "Int type parameter referencing a definition."
+        },
+        "containerUrl": {
+          "$ref": "#/definitions/containerUrl"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of product."
+        }
+      }
+    },
+    "url": {
+      "type": "string",
+      "format": "uri"
+    },
+    "containerUrl": {
+      "$ref": "#/definitions/url",
+      "description": "A shared Access Signature (SAS) BLOB container URL to contain the exported data."
+    },
+    "IntTypeDef": {
+      "type": "integer",
+      "format": "int64",
+      "description": "integer type common definition"
+    },
+    "date": {
+      "type": "string",
+      "format": "date",
+      "description": "A date as defined by full-date in RFC3339."
+    },
+    "Tags": {
+      "type": "string",
+      "description": "Tags are a list of key-value pairs that describe the resource. These tags can be used in viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key no greater than 128 characters and value no greater than 256 characters."
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParamterer": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Subscription ID.",
+      "required": true,
+      "type": "string"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "API ID.",
+      "required": true,
+      "type": "string"
+    }
+  }
+}

--- a/Tests/data/CompositeSwaggerTest/swagger-2.json
+++ b/Tests/data/CompositeSwaggerTest/swagger-2.json
@@ -1,0 +1,232 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger 2",
+    "description": "Swagger 2 documentation.",
+    "version": "2015-05-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [ "application/json" ],
+  "consumes": [ "application/json" ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resource2?api-version={apiVersion}": {
+      "get": {
+        "operationId": "SimpleGet2",
+        "summary": "Get product",
+        "description": "Operation description.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParamterer"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "tags": [
+          "Redis"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resources",
+            "schema": {
+              "$ref": "#/definitions/Product2"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Resource2_Create",
+        "summary": "Create product",
+        "description": "Operation description.",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Payload",
+            "required": true,
+            "schema": { "$ref": "#/definitions/Product2" }
+          },
+          {
+            "name": "apiVersion",
+            "in": "path",
+            "description": "API ID.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Redis"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of caches"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Resource_CreateOrUpdate",
+        "summary": "Create or update product",
+        "description": "Operation description.",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "Subscription ID.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Payload",
+            "required": true,
+            "schema": { "$ref": "#/definitions/Product" }
+          },
+          {
+            "name": "apiVersion",
+            "in": "path",
+            "description": "API ID.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Redis"
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of caches"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Product2": {
+      "description": "The product documentation.",
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of product."
+        }
+      }
+    },
+    "Product": {
+      "description": "The product documentation.",
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles."
+        },
+        "Tags": {
+          "$ref": "#/definitions/Tags",
+          "description": "Tags are a list of key-value pairs that describe the resource. These tags can be used in viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key no greater than 128 characters and value no greater than 256 characters."
+        },
+        "startDate": {
+          "$ref": "#/definitions/date",
+          "description": "The RFC3339 full-date of the start of the period for which data is exported."
+        },
+        "endDate": {
+          "$ref": "#/definitions/date",
+          "description": "The RFC3339 full-date of the end of the period for which data is exported."
+        },
+        "IntParamName": {
+          "$ref": "#/definitions/IntTypeDef",
+          "description": "Int type parameter referencing a definition."
+        },
+        "containerUrl": {
+          "$ref": "#/definitions/containerUrl"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of product."
+        }
+      }
+    },
+    "url": {
+      "type": "string",
+      "format": "uri"
+    },
+    "containerUrl": {
+      "$ref": "#/definitions/url",
+      "description": "A shared Access Signature (SAS) BLOB container URL to contain the exported data."
+    },
+    "IntTypeDef": {
+      "type": "integer",
+      "format": "int64",
+      "description": "integer type common definition"
+    },
+    "date": {
+      "type": "string",
+      "format": "date",
+      "description": "A date as defined by full-date in RFC3339."
+    },
+    "Tags": {
+      "type": "string",
+      "description": "Tags are a list of key-value pairs that describe the resource. These tags can be used in viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key no greater than 128 characters and value no greater than 256 characters."
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "fields": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParamterer": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Subscription ID.",
+      "required": true,
+      "type": "string"
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "API ID.",
+      "required": true,
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
Resolves #145 .
- Added logic for expanding the non-model definition references and for ignoring the non-model definitions in Format XML and 'New-<Definition>Object' functions.
- Updated logic for determining the array element type and dictionary element type.