### PR TITLE
Fix for Module generation error when module name and swagger infoname are same

### DIFF
--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -189,13 +189,20 @@ function Get-SwaggerInfo {
     }
 
     $NamespaceVersionSuffix = "v$("$ModuleVersion" -replace '\.','')"
+    $NameSpace = "Microsoft.PowerShell.$ModuleName.$NamespaceVersionSuffix"
+
+    # AutoRest generates client name with 'Client' appended to info title when a NameSpace part is same as the info name.
+    if($NameSpace.Split('.', [System.StringSplitOptions]::RemoveEmptyEntries) -contains $infoName)
+    {
+        $infoName = $infoName + 'Client'
+    }
 
     return @{
         InfoVersion = $infoVersion
         InfoTitle = $infoTitle
         InfoName = $infoName
         Version = $ModuleVersion
-        NameSpace = "Microsoft.PowerShell.$ModuleName.$NamespaceVersionSuffix"
+        NameSpace = $NameSpace
         ModuleName = $ModuleName
         Description = $Description
         ContactName = $ContactName

--- a/Tests/data/CompositeSwaggerTest/composite-swagger.json
+++ b/Tests/data/CompositeSwaggerTest/composite-swagger.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "title": "CompositeSwaggerClient",
+    "title": "CompositeSwaggerModule",
     "description": "Swagger description."
   },
   "documents": [


### PR DESCRIPTION
When a NameSpace part is same as the InfoName, AutoRest generates client name with 'Client' appended to the InfoName.
Resolves #174 .