### PR TITLE
Support global parameters

### DIFF
--- a/PSSwagger/PSSwagger.Constants.ps1
+++ b/PSSwagger/PSSwagger.Constants.ps1
@@ -166,10 +166,7 @@ $functionBodyStr = @'
 
     $clientName = New-Object -TypeName $fullModuleName -ArgumentList `$serviceCredentials,`$delegatingHandler$apiVersion
 
-    if(Get-Member -InputObject $clientName -Name 'SubscriptionId' -MemberType Property)
-    {
-        $clientName.SubscriptionId = `$SubscriptionId
-    }
+    $GlobalParameterBlock
     $clientName.BaseUri = `$ResourceManagerUrl$oDataExpressionBlock
     $parameterGroupsExpressionBlock
 
@@ -313,6 +310,13 @@ $ApiVersionStr = @'
     if(Get-Member -InputObject $clientName -Name 'ApiVersion' -MemberType Property)
     {
         $clientName.ApiVersion = "$infoVersion"
+    }
+'@
+
+$GlobalParameterBlockStr = @'
+    if(Get-Member -InputObject `$clientName -Name '$globalParameterName' -MemberType Property)
+    {
+        `$clientName.$globalParameterName = $globalParameterValue
     }
 '@
 

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -295,6 +295,7 @@ function New-PSSwaggerModule
         DefaultCommandPrefix = $DefaultCommandPrefix
         SwaggerSpecFilePaths = $SwaggerSpecFilePaths
         DefinitionFunctionsDetails = $DefinitionFunctionsDetails
+        AzureSpec = $UseAzureCsharpGenerator
     }
     $swaggerDict = ConvertTo-SwaggerDictionary @ConvertToSwaggerDictionary_params
     $nameSpace = $swaggerDict['info'].NameSpace

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -3,7 +3,7 @@ Describe "Basic API" -Tag ScenarioTest {
     BeforeAll {
         Initialize-Test -GeneratedModuleName "Generated.Basic.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "PsSwaggerTestBasic" `
                         -TestSpecFileName "PsSwaggerTestBasicSpec.json" -TestDataFileName "PsSwaggerTestBasicData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot -UseAzureCSharpGenerator
 
         # Import generated module
         Write-Verbose "Importing modules"
@@ -64,7 +64,7 @@ Describe "All Operations: Basic" -Tag ScenarioTest {
     BeforeAll {
         Initialize-Test -GeneratedModuleName "Generated.TypesTest.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "OperationTypes" `
                         -TestSpecFileName "OperationTypesSpec.json" -TestDataFileName "OperationTypesData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot -UseAzureCSharpGenerator
 
         # Import generated module
         Write-Verbose "Importing modules"
@@ -147,7 +147,7 @@ Describe "Get/List tests" -Tag ScenarioTest {
     BeforeAll {
         Initialize-Test -GeneratedModuleName "Generated.GetList.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "GetListTests" `
                         -TestSpecFileName "GetListTestsSpec.json" -TestDataFileName "GetListTestsData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot -UseAzureCSharpGenerator
 
         # Import generated module
         Write-Verbose "Importing modules"
@@ -203,7 +203,7 @@ Describe "Optional parameter tests" -Tag ScenarioTest {
     BeforeAll {
         Initialize-Test -GeneratedModuleName "Generated.Optional.Module" -GeneratedModuleVersion "0.0.2" -TestApiName "OptionalParametersTests" `
                         -TestSpecFileName "OptionalParametersTestsSpec.json" -TestDataFileName "OptionalParametersTestsData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot -UseAzureCSharpGenerator
 
         # Import generated module
         Write-Verbose "Importing modules"
@@ -270,7 +270,7 @@ Describe "ParameterTypes tests" {
     BeforeAll {
         Initialize-Test -GeneratedModuleName "Generated.ParmTypes.Module" -GeneratedModuleVersion "0.0.2" -TestApiName "ParameterTypes" `
                         -TestSpecFileName "ParameterTypesSpec.json" -TestDataFileName "ParameterTypesData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot -UseAzureCSharpGenerator
 
         # Import generated module
         Write-Verbose "Importing modules"
@@ -351,6 +351,11 @@ Describe "ParameterTypes tests" {
 
         It "Test OData parameters" {
             Get-Cupcake -Filter "filter" -Expand "expand" -Select "select"
+        }
+
+        It "Test global parameters" {
+            $results = Get-Cookie -TestGlobalParameter "test"
+            $results.Length | should be 1
         }
     }
 

--- a/Tests/TestUtilities.psm1
+++ b/Tests/TestUtilities.psm1
@@ -57,13 +57,14 @@ function Initialize-Test {
         [string]$TestDataFileName,
         [string]$PsSwaggerPath,
         [string]$TestRootPath,
-        [string]$GeneratedModuleVersion
+        [string]$GeneratedModuleVersion,
+        [switch]$UseAzureCSharpGenerator
     )
 
     Compile-TestAssembly -TestAssemblyName "$global:testRunGuid.dll" `
                          -TestAssemblyPath (Join-Path "$TestRootPath" "PSSwagger.TestUtilities") `
                          -TestCSharpFilePath (Join-Path "$TestRootPath" "PSSwagger.TestUtilities" | Join-Path -ChildPath "TestCredentials.cs") `
-                         -CompilationUtilsPath (Join-Path $PsSwaggerPath "Utils.ps1") -UseAzureCSharpGenerator $false -Verbose
+                         -CompilationUtilsPath (Join-Path $PsSwaggerPath "Utils.ps1") -UseAzureCSharpGenerator $UseAzureCSharpGenerator -Verbose
 
     
 
@@ -89,7 +90,7 @@ function Initialize-Test {
         }"
     } else {
         Import-Module (Join-Path "$PsSwaggerPath" "PSSwagger.psd1") -Force
-        New-PSSwaggerModule -SwaggerSpecPath (Join-Path -Path "$testCaseDataLocation" -ChildPath $TestSpecFileName) -Path "$generatedModulesPath" -Name $GeneratedModuleName -Verbose -NoAssembly
+        New-PSSwaggerModule -SwaggerSpecPath (Join-Path -Path "$testCaseDataLocation" -ChildPath $TestSpecFileName) -Path "$generatedModulesPath" -Name $GeneratedModuleName -Verbose -NoAssembly -UseAzureCSharpGenerator:$UseAzureCSharpGenerator
     }
 
     # Copy json-server data since it's updated live

--- a/Tests/data/ParameterTypes/ParameterTypesData.json
+++ b/Tests/data/ParameterTypes/ParameterTypesData.json
@@ -42,5 +42,17 @@
       "password": "test2",
       "poisoned": true
     }
+  ],
+  "cookies": [
+    {
+      "id": "1",
+      "api-version": "test",
+      "TestGlobalParameter": "test"
+    },
+    {
+      "id": "2",
+      "api-version": "2017-03-24",
+      "TestGlobalParameter": "test"
+    }
   ]
 }

--- a/Tests/data/ParameterTypes/ParameterTypesSpec.json
+++ b/Tests/data/ParameterTypes/ParameterTypesSpec.json
@@ -162,6 +162,44 @@
                 },
                 "x-ms-odata": "#/definitions/Cupcake"
             }
+        },
+        "/cookies": {
+            "get": {
+                "summary": "List all cookies matching parameters",
+                "operationId": "Cookie_Get",
+                "description": "List all cookies matching parameters",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/TestGlobalParameter"
+                    }
+                ],
+                "tags": [
+                    "Cookies"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "All cookie entities",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Cookie"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -228,6 +266,23 @@
                 }
             }
         },
+        "Cookie": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Unique identifier"
+                },
+                "api-version": {
+                    "type": "string",
+                    "description": "API version"
+                },
+                "TestGlobalParameter": {
+                    "type": "string",
+                    "description": "Something"
+                }
+            }
+        },
         "Error": {
             "type": "object",
             "properties": {
@@ -256,6 +311,14 @@
             "required": true,
             "type": "string",
             "description": "The API version to be used with the HTTP request."
+        },
+        "TestGlobalParameter": {
+            "name": "TestGlobalParameter",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "Stuff",
+            "default": "defaultValue"
         }
     }
 }


### PR DESCRIPTION
Resolves #118 

- Generic support for global parameters, no default  value support
- If UseAzureCSharpGenerator is specified, also accounts for Azure-specific global parameters "subscriptionId" and "api-version"