### PR TITLE
Support global parameters

### DIFF
--- a/PSSwagger/PSSwagger.Constants.ps1
+++ b/PSSwagger/PSSwagger.Constants.ps1
@@ -166,10 +166,7 @@ $functionBodyStr = @'
 
     $clientName = New-Object -TypeName $fullModuleName -ArgumentList `$serviceCredentials,`$delegatingHandler$apiVersion
 
-    if(Get-Member -InputObject $clientName -Name 'SubscriptionId' -MemberType Property)
-    {
-        $clientName.SubscriptionId = `$SubscriptionId
-    }
+    $GlobalParameterBlock
     $clientName.BaseUri = `$ResourceManagerUrl$oDataExpressionBlock
     $parameterGroupsExpressionBlock
 
@@ -313,6 +310,13 @@ $ApiVersionStr = @'
     if(Get-Member -InputObject $clientName -Name 'ApiVersion' -MemberType Property)
     {
         $clientName.ApiVersion = "$infoVersion"
+    }
+'@
+
+$GlobalParameterBlockStr = @'
+    if(Get-Member -InputObject `$clientName -Name '$globalParameterName' -MemberType Property)
+    {
+        `$clientName.$globalParameterName = $globalParameterValue
     }
 '@
 

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -295,6 +295,7 @@ function New-PSSwaggerModule
         DefaultCommandPrefix = $DefaultCommandPrefix
         SwaggerSpecFilePaths = $SwaggerSpecFilePaths
         DefinitionFunctionsDetails = $DefinitionFunctionsDetails
+        AzureSpec = $UseAzureCsharpGenerator
     }
     $swaggerDict = ConvertTo-SwaggerDictionary @ConvertToSwaggerDictionary_params
     $nameSpace = $swaggerDict['info'].NameSpace

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -60,7 +60,6 @@ function Get-SwaggerSpecPathInfo
                                         -SwaggerDict $swaggerDict `
                                         -DefinitionFunctionsDetails $DefinitionFunctionsDetails `
                                         -ParameterGroupCache $ParameterGroupCache
-
             $responses = ""
             if((Get-Member -InputObject $_.value -Name 'responses') -and $_.value.responses) {
                 $responses = $_.value.responses 
@@ -239,15 +238,35 @@ function New-SwaggerPath
     $paramHelp = ''
     $parametersToAdd = @{}
     $parameterHitCount = @{}
+    $globalParameterBlock = ''
     foreach ($parameterSetDetail in $parameterSetDetails) {
         $parameterSetDetail.ParameterDetails.GetEnumerator() | ForEach-Object {
             $parameterDetails = $_.Value
-            if ($parameterDetails.ContainsKey('x_ms_parameter_grouping_group')) {
-                foreach ($parameterDetailEntry in $parameterDetails.'x_ms_parameter_grouping_group'.GetEnumerator()) {
-                    Add-UniqueParameter -CandidateParameterDetails $parameterDetailEntry.Value -OperationId $parameterSetDetail.OperationId -ParametersToAdd $parametersToAdd -ParameterHitCount $parameterHitCount
+            $parameterRequiresAdding = $true
+            if ($parameterDetails.ContainsKey('x_ms_parameter_location') -and ('client' -eq $parameterDetails.'x_ms_parameter_location')) {
+                if ($parameterDetails.ContainsKey('ReadOnlyGlobalParameter') -and $parameterDetails.ReadOnlyGlobalParameter) {
+                    $parameterRequiresAdding = $false
+                } else {
+                    $globalParameterName = $parameterDetails.Name
+                    $globalParameterValue = "```$$($parameterDetails.Name)"
+                    if ($parameterDetails.ContainsKey('ConstantValue') -and $parameterDetails.ConstantValue) {
+                        # A parameter with a constant value doesn't need to be in the parameter block
+                        $parameterRequiresAdding = $false
+                        $globalParameterValue = $parameterDetails.ConstantValue
+                    }
+                    
+                    $globalParameterBlock += [Environment]::NewLine + $executionContext.InvokeCommand.ExpandString($GlobalParameterBlockStr)
                 }
-            } else {
-                Add-UniqueParameter -CandidateParameterDetails $parameterDetails -OperationId $parameterSetDetail.OperationId -ParametersToAdd $parametersToAdd -ParameterHitCount $parameterHitCount
+            }
+
+            if ($parameterRequiresAdding) {
+                if ($parameterDetails.ContainsKey('x_ms_parameter_grouping_group')) {
+                    foreach ($parameterDetailEntry in $parameterDetails.'x_ms_parameter_grouping_group'.GetEnumerator()) {
+                        Add-UniqueParameter -CandidateParameterDetails $parameterDetailEntry.Value -OperationId $parameterSetDetail.OperationId -ParametersToAdd $parametersToAdd -ParameterHitCount $parameterHitCount
+                    }
+                } else {
+                    Add-UniqueParameter -CandidateParameterDetails $parameterDetails -OperationId $parameterSetDetail.OperationId -ParametersToAdd $parametersToAdd -ParameterHitCount $parameterHitCount
+                }
             }
         }
     }
@@ -385,6 +404,7 @@ function New-SwaggerPath
                                 ParameterSetDetails = $FunctionDetails['ParameterSetDetails']
                                 ODataExpressionBlock = $oDataExpressionBlock
                                 ParameterGroupsExpressionBlock = $parameterGroupsExpressionBlock
+                                GlobalParameterBlock = $GlobalParameterBlock
                                 SwaggerDict = $SwaggerDict
                                 SwaggerMetaDict = $SwaggerMetaDict
                            }
@@ -473,6 +493,30 @@ function Set-ExtendedCodeMetadata {
                 return
             }
 
+            # Process global parameters
+            $paramObject = $parameterSetDetail.ParameterDetails
+            $clientType.GetProperties() | ForEach-Object {
+                $propertyName = $_.Name
+                $matchingParamDetail = $paramObject.GetEnumerator() | Where-Object { $_.Value.Name -eq $propertyName } | Select-Object -First 1 -ErrorAction Ignore
+                if ($matchingParamDetail) {
+                    $setSingleParameterMetadataParms = @{
+                                                            CommandName = $FunctionDetails['CommandName']
+                                                            Name = $matchingParamDetail.Value.Name
+                                                            HasDefaultValue = $false
+                                                            IsGrouped = $false
+                                                            Type = $_.PropertyType
+                                                            MatchingParamDetail = $matchingParamDetail.Value
+                                                            ResultRecord = $resultRecord
+                                                        }
+                    if (-not (Set-SingleParameterMetadata @setSingleParameterMetadataParms))
+                    {
+                        Export-CliXml -InputObject $ResultRecord -Path $CliXmlTmpPath
+                        $errorOccurred = $true
+                        return
+                    }
+                }
+            }
+
             if ($operationsWithSuffix) {
                 $operationName = $operationsWithSuffix.Substring(1)
                 $propertyObject = $clientType.GetProperties() | Where-Object { $_.Name -eq $operationName } | Select-Object -First 1 -ErrorAction Ignore
@@ -511,8 +555,7 @@ function Set-ExtendedCodeMetadata {
                 $errorOccurred = $true
                 return
             }
-            # TODO: The parameter group will never be in the parameter details list
-            $paramObject = $parameterSetDetail.ParameterDetails
+
             $ParamList = @()
             $oDataQueryFound = $false
             $methodInfo.GetParameters() | Sort-Object -Property Position | ForEach-Object {
@@ -599,11 +642,10 @@ function Set-ExtendedCodeMetadata {
                     }
                 }
             }
-
+            
             if ($parameterSetDetail.ContainsKey('x-ms-odata') -and $parameterSetDetail.'x-ms-odata') {
                 $paramObject.GetEnumerator() | ForEach-Object {
                     $paramDetail = $_.Value
-
                     if (-not $paramDetail.ContainsKey('ExtendedData')) {
                         $metadata = @{
                             IsODataParameter = $true

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -3,7 +3,7 @@ Describe "Basic API" -Tag ScenarioTest {
     BeforeAll {
         Initialize-Test -GeneratedModuleName "Generated.Basic.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "PsSwaggerTestBasic" `
                         -TestSpecFileName "PsSwaggerTestBasicSpec.json" -TestDataFileName "PsSwaggerTestBasicData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot -UseAzureCSharpGenerator
 
         # Import generated module
         Write-Verbose "Importing modules"
@@ -64,7 +64,7 @@ Describe "All Operations: Basic" -Tag ScenarioTest {
     BeforeAll {
         Initialize-Test -GeneratedModuleName "Generated.TypesTest.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "OperationTypes" `
                         -TestSpecFileName "OperationTypesSpec.json" -TestDataFileName "OperationTypesData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot -UseAzureCSharpGenerator
 
         # Import generated module
         Write-Verbose "Importing modules"
@@ -147,7 +147,7 @@ Describe "Get/List tests" -Tag ScenarioTest {
     BeforeAll {
         Initialize-Test -GeneratedModuleName "Generated.GetList.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "GetListTests" `
                         -TestSpecFileName "GetListTestsSpec.json" -TestDataFileName "GetListTestsData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot -UseAzureCSharpGenerator
 
         # Import generated module
         Write-Verbose "Importing modules"
@@ -203,7 +203,7 @@ Describe "Optional parameter tests" -Tag ScenarioTest {
     BeforeAll {
         Initialize-Test -GeneratedModuleName "Generated.Optional.Module" -GeneratedModuleVersion "0.0.2" -TestApiName "OptionalParametersTests" `
                         -TestSpecFileName "OptionalParametersTestsSpec.json" -TestDataFileName "OptionalParametersTestsData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot -UseAzureCSharpGenerator
 
         # Import generated module
         Write-Verbose "Importing modules"
@@ -270,7 +270,7 @@ Describe "ParameterTypes tests" {
     BeforeAll {
         Initialize-Test -GeneratedModuleName "Generated.ParmTypes.Module" -GeneratedModuleVersion "0.0.2" -TestApiName "ParameterTypes" `
                         -TestSpecFileName "ParameterTypesSpec.json" -TestDataFileName "ParameterTypesData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot -UseAzureCSharpGenerator
 
         # Import generated module
         Write-Verbose "Importing modules"
@@ -351,6 +351,11 @@ Describe "ParameterTypes tests" {
 
         It "Test OData parameters" {
             Get-Cupcake -Filter "filter" -Expand "expand" -Select "select"
+        }
+
+        It "Test global parameters" {
+            $results = Get-Cookie -TestGlobalParameter "test"
+            $results.Length | should be 1
         }
     }
 

--- a/Tests/TestUtilities.psm1
+++ b/Tests/TestUtilities.psm1
@@ -57,13 +57,14 @@ function Initialize-Test {
         [string]$TestDataFileName,
         [string]$PsSwaggerPath,
         [string]$TestRootPath,
-        [string]$GeneratedModuleVersion
+        [string]$GeneratedModuleVersion,
+        [switch]$UseAzureCSharpGenerator
     )
 
     Compile-TestAssembly -TestAssemblyName "$global:testRunGuid.dll" `
                          -TestAssemblyPath (Join-Path "$TestRootPath" "PSSwagger.TestUtilities") `
                          -TestCSharpFilePath (Join-Path "$TestRootPath" "PSSwagger.TestUtilities" | Join-Path -ChildPath "TestCredentials.cs") `
-                         -CompilationUtilsPath (Join-Path $PsSwaggerPath "Utils.ps1") -UseAzureCSharpGenerator $false -Verbose
+                         -CompilationUtilsPath (Join-Path $PsSwaggerPath "Utils.ps1") -UseAzureCSharpGenerator $UseAzureCSharpGenerator -Verbose
 
     
 
@@ -89,7 +90,7 @@ function Initialize-Test {
         }"
     } else {
         Import-Module (Join-Path "$PsSwaggerPath" "PSSwagger.psd1") -Force
-        New-PSSwaggerModule -SwaggerSpecPath (Join-Path -Path "$testCaseDataLocation" -ChildPath $TestSpecFileName) -Path "$generatedModulesPath" -Name $GeneratedModuleName -Verbose -NoAssembly
+        New-PSSwaggerModule -SwaggerSpecPath (Join-Path -Path "$testCaseDataLocation" -ChildPath $TestSpecFileName) -Path "$generatedModulesPath" -Name $GeneratedModuleName -Verbose -NoAssembly -UseAzureCSharpGenerator:$UseAzureCSharpGenerator
     }
 
     # Copy json-server data since it's updated live

--- a/Tests/data/ParameterTypes/ParameterTypesData.json
+++ b/Tests/data/ParameterTypes/ParameterTypesData.json
@@ -42,5 +42,17 @@
       "password": "test2",
       "poisoned": true
     }
+  ],
+  "cookies": [
+    {
+      "id": "1",
+      "api-version": "test",
+      "TestGlobalParameter": "test"
+    },
+    {
+      "id": "2",
+      "api-version": "2017-03-24",
+      "TestGlobalParameter": "test"
+    }
   ]
 }

--- a/Tests/data/ParameterTypes/ParameterTypesSpec.json
+++ b/Tests/data/ParameterTypes/ParameterTypesSpec.json
@@ -162,6 +162,44 @@
                 },
                 "x-ms-odata": "#/definitions/Cupcake"
             }
+        },
+        "/cookies": {
+            "get": {
+                "summary": "List all cookies matching parameters",
+                "operationId": "Cookie_Get",
+                "description": "List all cookies matching parameters",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/TestGlobalParameter"
+                    }
+                ],
+                "tags": [
+                    "Cookies"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "All cookie entities",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Cookie"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -228,6 +266,23 @@
                 }
             }
         },
+        "Cookie": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Unique identifier"
+                },
+                "api-version": {
+                    "type": "string",
+                    "description": "API version"
+                },
+                "TestGlobalParameter": {
+                    "type": "string",
+                    "description": "Something"
+                }
+            }
+        },
         "Error": {
             "type": "object",
             "properties": {
@@ -256,6 +311,14 @@
             "required": true,
             "type": "string",
             "description": "The API version to be used with the HTTP request."
+        },
+        "TestGlobalParameter": {
+            "name": "TestGlobalParameter",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "Stuff",
+            "default": "defaultValue"
         }
     }
 }


### PR DESCRIPTION
Resolves #118

- Generic support for global parameters, no default value support
- If UseAzureCSharpGenerator is specified, also accounts for Azure-specific global parameters "subscriptionId" and "api-version"
