### PR TITLE
Added required changes to support both classes for getting AutoRest generated type name.

### DIFF
--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -1448,7 +1448,7 @@ function Get-CSharpModelName
     }
     else
     {
-        return $Name
+        return $Name.Replace('[','').Replace(']','')
     }
 }
 


### PR DESCRIPTION
AutoRest renamed CSharpCodeNamer class to CodeNamerCs class in 1.0.0 builds. 
Added required changes to support both classes for getting AutoRest generated type name.