### PR TITLE
Update Get-PathCommandName functionality

### DIFF
--- a/PSSwagger/Trie.ps1
+++ b/PSSwagger/Trie.ps1
@@ -1,17 +1,18 @@
 function New-Trie {
-	return @{}
+    return @{}
 }
 
 function Add-WordToTrie {
-	param(
+    param(
         [Parameter(Mandatory=$true)]
-		[string]$Word,
+        [string]$Word,
         [Parameter(Mandatory=$true)]
-		[hashtable]$Trie
-	)
+        [hashtable]$Trie
+    )
 
-	$CurrentLevel = $Trie
-	$letter = $Word[0]
+    $CurrentLevel = $Trie
+    $Word = $Word.ToLower()
+    $letter = $Word[0]
 
     if (-not $CurrentLevel.ContainsKey($letter)) {
         $CurrentLevel[$letter] = @{}
@@ -34,6 +35,7 @@ function Test-Trie {
         [hashtable]$Trie
     )
 
+    $Letter = [char]::ToLower($Letter)
     if ($Trie.ContainsKey($Letter)) {
         return $Trie[$Letter]
     }

--- a/Tests/PSSwagger.Unit.Tests.ps1
+++ b/Tests/PSSwagger.Unit.Tests.ps1
@@ -1,0 +1,54 @@
+Import-Module (Join-Path "$PSScriptRoot" "TestUtilities.psm1") -DisableNameChecking
+Describe "PSSwagger Unit Tests" -Tag @('BVT', 'DRT', 'UnitTest', 'P0') {
+
+    BeforeAll {
+        $PSSwaggerModulePath = Split-Path -Path $PSScriptRoot -Parent | Join-Path -ChildPath 'PSSwagger'
+        Import-Module -Name $PSSwaggerModulePath -Force
+    }
+
+    InModuleScope PSSwagger {
+        Context "Get-PathCommandName Unit Tests" {
+            It "Get-PathCommandName should return command names with proper verb for VM_CreateOrUpdateWithNounSuffix operationid" {
+                $CommandNames = Get-PathCommandName -OperationId VM_CreateOrUpdateWithNounSuffix
+                $CommandNames -CContains 'New-VMWithNounSuffix' | Should Be $True
+                $CommandNames -CContains 'Set-VMWithNounSuffix' | Should Be $True
+            }
+
+            It "Get-PathCommandName should return command names with proper verb for VM_createorupdatewithnounsuffix operationid" {
+                $CommandNames = Get-PathCommandName -OperationId VM_createorupdatewithnounsuffix
+                $CommandNames -CContains 'New-VMWithnounsuffix' | Should Be $True
+                $CommandNames -CContains 'Set-VMWithnounsuffix' | Should Be $True
+            }
+
+            It "Get-PathCommandName should return command name with proper verb for VM_createOrWithNounSuffix operationid" {
+                Get-PathCommandName -OperationId VM_createOrWithNounSuffix | Should BeExactly 'New-VMORWithNounSuffix'
+            }
+
+            It "Get-PathCommandName should return command name with proper verb for VM_migrateWithNounSuffix operationid" {
+                Get-PathCommandName -OperationId VM_migrateWithNounSuffix | Should BeExactly 'Migrate-VMWithNounSuffix'
+            }
+
+            It "Get-PathCommandName should return command name with proper verb for CreateFooResource operationid" {
+                Get-PathCommandName -OperationId CreateFooResource | Should BeExactly 'New-FooResource'
+            }
+
+            It "Get-PathCommandName should return command names with proper verb for createorupdatebarResource operationid" {
+                $CommandNames = Get-PathCommandName -OperationId createorupdatebarResource
+                $CommandNames -CContains 'New-BarResource' | Should BeExactly $True
+                $CommandNames -CContains 'Set-BarResource' | Should BeExactly $True
+            }
+
+            It "Get-PathCommandName should return command name with proper verb for anotherFooResource_createFoo operationid" {
+                Get-PathCommandName -OperationId anotherFooResource_createFoo | Should BeExactly 'New-AnotherFooResource'
+            }
+
+            It "Get-PathCommandName should return command name with proper verb for FooResource_createresource operationid" {
+                Get-PathCommandName -OperationId FooResource_createresource | Should BeExactly 'New-FooResource'
+            }
+
+            It "Get-PathCommandName should return proper command name for abcd operationid" {
+                Get-PathCommandName -OperationId abcd | Should BeExactly 'Abcd'
+            }
+        }
+    }
+}

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -488,7 +488,7 @@ Describe "AzureExtensions" {
         }
 
         It "Test parameter group when operation ID has no hyphens" {
-            $results = GroupTestsNoHyphen -Parm "test"
+            $results = Group-TestsNoHyphen -Parm "test"
         }
 
         It "Test parameter group with flattened parameters" {


### PR DESCRIPTION
Updated Get-PathCommandName with following changes
- Added support for generating verb-noun command name for operationIds without '_' (UnderScore).
- Added approved verbs to the command verb trie.
- Added required changes to get the Pascal cased Verb and Noun in command names.
- Ensured that $script:CmdVerbTrie gets populated with verb names from the verbmap.
- Ensured that proper noun suffix from verb string gets appended to the command noun.
- Ensured that Trie functions work with lower cased letters too.
- Ignore Uppercase letter checking for first word start position.
- Added corresponding unit tests.