### PR TITLE
Add support for generating commands for nested definitions of response types used in Swagger operations

### DIFF
--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -794,8 +794,8 @@ function Get-ParamType
             }
             elseif((Get-Member -InputObject $ParameterJsonObject.Items -Name 'Type') -and $ParameterJsonObject.Items.Type)
             {
-                $ArrayItemType = Get-PSTypeFromSwaggerObject -JsonObject $ParameterJsonObject.Items
-                $paramType = "$($ArrayItemType)[]"
+                $ReferenceTypeName = Get-PSTypeFromSwaggerObject -JsonObject $ParameterJsonObject.Items
+                $paramType = "$($ReferenceTypeName)[]"
             }
         }
         elseif ((Get-Member -InputObject $ParameterJsonObject -Name 'AdditionalProperties') -and 
@@ -924,7 +924,7 @@ function Get-ParamType
         if($DefinitionFunctionsDetails.ContainsKey($ReferenceTypeName)) {
             $ReferencedDefinitionDetails = $DefinitionFunctionsDetails[$ReferenceTypeName]
         }
-        $ReferencedDefinitionDetails['GenerateDefinitionCmdlet'] = $true
+        $ReferencedDefinitionDetails['UsedAsPathOperationInputType'] = $true
     }
 
     if($paramType -and 

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -434,6 +434,20 @@ Describe "ParameterTypes tests" -Tag @('ParameterTypes','ScenarioTest') {
             $command3.Parameters.ContainsKey('Value') | Should Be $True
             $command3.Parameters.Value.ParameterType.Name | Should be 'NamespaceModel[]'
         }
+
+        It "Test Definition commands 'New-<NestedDefinition>Object' for nested definitions" {
+            $ModuleName = 'Generated.ParamTypes.Module'
+            $ev = $null
+            $CommandList = Get-Command -Module $ModuleName -ErrorVariable ev
+            $ev | Should BeNullOrEmpty
+            
+            $CommandNames = @('New-FieldDefinitionObject',
+                              'New-NamespaceNestedTypeObject',
+                              'New-KeyCredentialObject')
+            $CommandNames | ForEach-Object {
+                $CommandList.Name -CContains $_ | Should be $True
+            }
+        }
     }
 
     AfterAll {

--- a/Tests/data/ParameterTypes/ParameterTypesSpec.json
+++ b/Tests/data/ParameterTypes/ParameterTypesSpec.json
@@ -115,9 +115,13 @@
                         "in": "query",
                         "required": false,
                         "type": "string",
-                        "enum": [ "resourceType eq 'Test.Namespace/ServiceNameA'", "resourceType eq 'Test.Namespace/ServiceNameZ'", "OtherValidValue" ],
+                        "enum": [
+                            "resourceType eq 'Test.Namespace/ServiceNameA'",
+                            "resourceType eq 'Test.Namespace/ServiceNameZ'",
+                            "OtherValidValue"
+                        ],
                         "description": "The filter to apply on the operation."
-					},
+                    },
                     {
                         "name": "$filter",
                         "in": "query",
@@ -402,7 +406,7 @@
                 }
             },
             "description": "The workflow properties."
-        },    
+        },
         "Object": {
             "type": "object",
             "properties": {}
@@ -437,9 +441,88 @@
                     "format": "date-time",
                     "readOnly": true,
                     "description": "Gets the created time."
+                },
+                "NamespaceNestedTypeParam": {
+                    "$ref": "#/definitions/NamespaceNestedType",
+                    "description": "Description of NamespaceNestedTypeParam."
+                },
+                "keyCredentials": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/KeyCredential"
+                    },
+                    "description": "Gets or sets the list of KeyCredential objects"
+                },
+                "fieldDefinitions": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/FieldDefinition"
+                    },
+                    "description": "Gets or sets the field definitions of the connection type."
                 }
             },
             "description": "Description of a namespace resource."
+        },
+        "FieldDefinition": {
+            "properties": {
+                "isEncrypted": {
+                    "type": "boolean",
+                    "description": "Gets or sets the isEncrypted flag of the connection field definition."
+                },
+                "isOptional": {
+                    "type": "boolean",
+                    "description": "Gets or sets the isOptional flag of the connection field definition."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Gets or sets the type of the connection field definition."
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "description": "Definition of the connection fields."
+        },
+        "KeyCredential": {
+            "properties": {
+                "startDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Start date."
+                },
+                "endDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "End date."
+                },
+                "value": {
+                    "type": "string",
+                    "description": "Key value."
+                },
+                "keyId": {
+                    "type": "string",
+                    "description": "Key ID."
+                },
+                "usage": {
+                    "type": "string",
+                    "description": "Usage. Acceptable values are 'Verify' and 'Sign'."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Type. Acceptable values are 'AsymmetricX509Cert' and 'Symmetric'."
+                }
+            },
+            "description": "Active Directory Key Credential information."
+        },
+        "NamespaceNestedType": {
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "Resource name"
+                }
+            },
+            "description": "Description of a NamespaceNestedType resource."
         },
         "NamespaceList": {
             "properties": {


### PR DESCRIPTION
Added support for generating definition commands 'New-<NestedDefinition>Object' for nested definitions of Swagger operation response types/definitions.

Resolves #192 .