### PR TITLE
Update logic for getting reference type names in composite swagger spec scenario

### DIFF
--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -233,7 +233,7 @@ function New-PSSwaggerModule
                 $FileName = Split-Path -Path $document -Leaf
                 if(Test-Path -Path $document -PathType Leaf)
                 {
-                    $SwaggerSpecFilePaths += $SwaggerDocumentPath
+                    $SwaggerSpecFilePaths += $document
                 }
                 elseif(Test-Path -Path (Join-Path -Path $SwaggerBaseDir -ChildPath $document) -PathType Leaf)
                 {


### PR DESCRIPTION
Added support for parameters with below reference type names.
`#../../<Parameters>.Json/parameters/<PARAMETERNAME>
 #../../<Definitions>.Json/definitions/<DEFINITIONNAME>`