### PR TITLE
Added support for x-ms-client-name in definition parameters.

### DIFF
--- a/PSSwagger/Definitions.psm1
+++ b/PSSwagger/Definitions.psm1
@@ -208,7 +208,11 @@ function Get-DefinitionParameters
             if((Get-Member -InputObject $_ -Name 'Name') -and $_.Name)
             {
                 $ParameterJsonObject = $_.Value
-                $ParameterName = Get-PascalCasedString -Name $_.Name
+                if ((Get-Member -InputObject $ParameterJsonObject -Name 'x-ms-client-name') -and $ParameterJsonObject.'x-ms-client-name') {
+                    $parameterName = Get-PascalCasedString -Name $ParameterJsonObject.'x-ms-client-name'
+                } else {
+                    $ParameterName = Get-PascalCasedString -Name $_.Name
+                }
 
                 if(($ParameterName -eq 'Properties') -and
                    (Get-Member -InputObject $ParameterJsonObject -Name 'x-ms-client-flatten') -and
@@ -393,16 +397,7 @@ function Get-DefinitionParameterType
 
         $x_ms_Client_flatten_DefinitionNames = @($ReferenceDefinitionName)
 
-        $ReferencedFunctionDetails = @{}
-        if($DefinitionFunctionsDetails.ContainsKey($ReferenceDefinitionName))
-        {
-            $ReferencedFunctionDetails = $DefinitionFunctionsDetails[$ReferenceDefinitionName]
-        }
-
-        $ReferencedFunctionDetails['Name'] = $ReferenceDefinitionName
-        $ReferencedFunctionDetails['IsUsedAs_x_ms_client_flatten'] = $true
-
-        $DefinitionFunctionsDetails[$ReferenceDefinitionName] = $ReferencedFunctionDetails
+        Set-TypeUsedAsClientFlatten -ReferenceTypeName $ReferenceDefinitionName -DefinitionFunctionsDetails $DefinitionFunctionsDetails
 
         # Add/Update FunctionDetails to $DefinitionFunctionsDetails
         $FunctionDetails = @{}

--- a/PSSwagger/PSSwagger.Common.Helpers/PSSwagger.Common.Helpers.psd1
+++ b/PSSwagger/PSSwagger.Common.Helpers/PSSwagger.Common.Helpers.psd1
@@ -7,12 +7,13 @@ CompanyName = 'Microsoft Corporation'
 Copyright = '(c) Microsoft Corporation. All rights reserved.'
 Description = 'PowerShell module with PSSwagger common helper functions'
 FunctionsToExport = @('Invoke-SwaggerCommandUtility',
-					  'New-PSSwaggerClientTracing',
-					  'Register-PSSwaggerClientTracing',
-					  'Unregister-PSSwaggerClientTracing',
+                      'New-PSSwaggerClientTracing',
+                      'Register-PSSwaggerClientTracing',
+                      'Unregister-PSSwaggerClientTracing',
                       'Get-SignedCodeContent',
                       'Get-OperatingSystemInfo',
                       'Get-XDGDirectory',
+                      'Get-PSCommonParameters',
                       'Invoke-PSSwaggerAssemblyCompilation'
                       'Get-PSSwaggerMsi',
                       'Get-PSSwaggerDependencyPackage',

--- a/PSSwagger/PSSwagger.Common.Helpers/PSSwagger.Common.Helpers.psm1
+++ b/PSSwagger/PSSwagger.Common.Helpers/PSSwagger.Common.Helpers.psm1
@@ -1519,7 +1519,7 @@ function Initialize-PSSwaggerUtilities {
         
         # It is required to import the generated assembly into the module scope 
         # to register the PSSwaggerJobSourceAdapter with the PowerShell Job infrastructure.
-        Import-Module -Name $PSSwaggerJobAssemblyPath
+        Import-Module -Name $PSSwaggerJobAssemblyPath -Verbose:$false
     }
 
     if(-not ('Microsoft.PowerShell.Commands.PSSwagger.PSSwaggerJob' -as [Type]))
@@ -1527,7 +1527,7 @@ function Initialize-PSSwaggerUtilities {
         Write-Error -Message ($LocalizedData.FailedToAddType -f ('PSSwaggerJob'))
     }
 
-    Import-Module -Name (Join-Path -Path "$PSScriptRoot" -ChildPath "PSSwaggerClientTracing.psm1")
+    Import-Module -Name (Join-Path -Path "$PSScriptRoot" -ChildPath 'PSSwaggerClientTracing.psm1') -Verbose:$false
 }
 
 function New-PSSwaggerClientTracing {

--- a/PSSwagger/PSSwagger.Constants.ps1
+++ b/PSSwagger/PSSwagger.Constants.ps1
@@ -23,7 +23,6 @@ $parameterDefString = @'
 $parameterDefaultValueString = ' = $parameterDefaultValue'
 
 $RootModuleContents = @'
-`$script:ServiceClientTracer = `$null
 Microsoft.PowerShell.Core\Set-StrictMode -Version Latest
 Microsoft.PowerShell.Utility\Import-LocalizedData  LocalizedData -filename $Name.Resources.psd1
 
@@ -372,7 +371,10 @@ $createObjectStr = @'
     `$Object = New-Object -TypeName $DefinitionTypeName
 
     `$PSBoundParameters.GetEnumerator() | ForEach-Object { 
-        `$Object.`$(`$_.Key) = `$_.Value
+        if(Get-Member -InputObject `$Object -Name `$_.Key -MemberType Property)
+        {
+            `$Object.`$(`$_.Key) = `$_.Value
+        }
     }
 
     if(Get-Member -InputObject `$Object -Name Validate -MemberType Method)

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -556,6 +556,18 @@ Describe "AzureExtensions" {
             $results = Get-CupcakeByFlavor -Flavor 'vanilla'
             $results.Count | should be 1
         }
+
+        It "Test x-ms-client-name for definition parameters" {
+            $cmdInfo = Get-Command New-VirtualMachineObject -ErrorVariable ev
+            $ev | Should BeNullOrEmpty
+            $cmdInfo.Parameters.ContainsKey('ClientNameForSku') | should be $true
+        }
+
+        It "'New-<Definition>Object' should not be generated for definitions used as x-ms-client-flatten" {
+            $cmdInfo = Get-Command New-CheckNameAvailabilityInputObject -ErrorVariable ev -ErrorAction SilentlyContinue
+            $cmdInfo = Should BeNullOrEmpty
+            $ev.FullyQualifiedErrorId | Should Be 'CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand'
+        }
     }
 
     AfterAll {

--- a/Tests/data/AzureExtensions/AzureExtensionsSpec.json
+++ b/Tests/data/AzureExtensions/AzureExtensionsSpec.json
@@ -19,8 +19,7 @@
                 "summary": "Get all cupcakes",
                 "operationId": "Cupcake_List",
                 "description": "List all cupcakes.",
-                "parameters": [
-                ],
+                "parameters": [],
                 "tags": [
                     "Cupcakes"
                 ],
@@ -82,8 +81,7 @@
                 "summary": "Get all cupcake batches",
                 "operationId": "CupcakeBatch_List",
                 "description": "List all cupcake batches.",
-                "parameters": [
-                ],
+                "parameters": [],
                 "tags": [
                     "CupcakeBatch"
                 ],
@@ -141,7 +139,7 @@
             }
         },
         "/groupTests/{pathParameter}": {
-             "get": {
+            "get": {
                 "summary": "Test path parameter group",
                 "operationId": "GroupTests_PathParameter",
                 "description": "Test path parameter group",
@@ -187,11 +185,11 @@
             }
         },
         "/groupTests/localAndGlobal": {
-             "get": {
-                 "summary": "Test local/global parameter group",
-                 "operationId": "GroupTest_MixedParameter",
-                 "description": "Test local/global parameter group",
-                 "parameters": [
+            "get": {
+                "summary": "Test local/global parameter group",
+                "operationId": "GroupTest_MixedParameter",
+                "description": "Test local/global parameter group",
+                "parameters": [
                     {
                         "name": "parm",
                         "in": "path",
@@ -205,11 +203,11 @@
                     {
                         "$ref": "#/parameters/GlobalParameter"
                     }
-                 ],
-                 "tags": [
+                ],
+                "tags": [
                     "Cupcake"
-                 ],
-                 "responses": {
+                ],
+                "responses": {
                     "200": {
                         "description": "Results",
                         "schema": {
@@ -225,8 +223,8 @@
                             "$ref": "#/definitions/Error"
                         }
                     }
-                 }
-             }
+                }
+            }
         },
         "/virtualMachines": {
             "put": {
@@ -264,8 +262,8 @@
                 "x-ms-long-running-operation": true
             }
         },
-         "/groupTests/postfixTest": {
-             "get": {
+        "/groupTests/postfixTest": {
+            "get": {
                 "summary": "Test postfix parameter group",
                 "operationId": "GroupTests_PostfixTest",
                 "description": "Test postfix parameter group",
@@ -302,9 +300,9 @@
                     }
                 }
             }
-         },
-         "/groupTests/noPostfixTest": {
-             "get": {
+        },
+        "/groupTests/noPostfixTest": {
+            "get": {
                 "summary": "Test postfix parameter group",
                 "operationId": "GroupTests_NoPostfixTest",
                 "description": "Test postfix parameter group",
@@ -315,8 +313,7 @@
                         "description": "x-ms-parameter-grouping test",
                         "required": true,
                         "type": "string",
-                        "x-ms-parameter-grouping": {
-                        }
+                        "x-ms-parameter-grouping": {}
                     }
                 ],
                 "tags": [
@@ -340,9 +337,9 @@
                     }
                 }
             }
-         },
-         "/groupTests/noHyphen": {
-             "get": {
+        },
+        "/groupTests/noHyphen": {
+            "get": {
                 "summary": "Test postfix parameter group",
                 "operationId": "GroupTestsNoHyphen",
                 "description": "Test postfix parameter group",
@@ -353,8 +350,7 @@
                         "description": "x-ms-parameter-grouping test",
                         "required": true,
                         "type": "string",
-                        "x-ms-parameter-grouping": {
-                        }
+                        "x-ms-parameter-grouping": {}
                     }
                 ],
                 "tags": [
@@ -378,9 +374,9 @@
                     }
                 }
             }
-         },
-         "/groupTests/flattened": {
-             "post": {
+        },
+        "/groupTests/flattened": {
+            "post": {
                 "summary": "Test flattened parameter group",
                 "operationId": "GroupTests_FlattenedParms",
                 "description": "Test flattened parameter group",
@@ -402,12 +398,11 @@
                 "tags": [
                     "Cupcake"
                 ],
-                "responses": {
-                }
+                "responses": {}
             }
-         },
-         "/groupTests/multipleGroups": {
-             "get": {
+        },
+        "/groupTests/multipleGroups": {
+            "get": {
                 "summary": "Test multiple parameter group",
                 "operationId": "GroupTests_MultipleGroups",
                 "description": "Test multiple parameter group",
@@ -454,11 +449,11 @@
                     }
                 }
             }
-         }
+        }
     },
     "x-ms-paths": {
         "/cupcakes?id={id}": {
-             "get": {
+            "get": {
                 "summary": "Get a cupcake",
                 "operationId": "Cupcake_GetById",
                 "description": "Get a cupcake.",
@@ -493,8 +488,8 @@
                 }
             }
         },
-         "/cupcakes?flavor={flavor}": {
-             "get": {
+        "/cupcakes?flavor={flavor}": {
+            "get": {
                 "summary": "Get a cupcake",
                 "operationId": "Cupcake_GetByFlavor",
                 "description": "Get a cupcake.",
@@ -524,6 +519,45 @@
                         "description": "Error",
                         "schema": {
                             "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/subscriptions/{subscriptionId}/providers/Microsoft.Search/checkNameAvailability": {
+            "post": {
+                "tags": [
+                    "Services"
+                ],
+                "description": "Checks whether or not the given Search service name is available for use. Search service names must be globally unique since they are part of the service URI (https://<name>.search.windows.net).",
+                "externalDocs": {
+                    "url": "https://aka.ms/search-manage"
+                },
+                "operationId": "Services_CheckNameAvailability",
+                "parameters": [
+                    {
+                        "name": "checkNameAvailabilityInput",
+                        "in": "body",
+                        "description": "The resource name and type to check.",
+                        "x-ms-client-flatten": true,
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CheckNameAvailabilityInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The name check completed. The response contains details of whether the name is valid and available. If the name is invalid, the response also contains a message explaining why not.",
+                        "schema": {
+                            "$ref": "#/definitions/CheckNameAvailabilityOutput"
+                        },
+                        "examples": {
+                            "application/json": {
+                                "nameAvailable": false,
+                                "reason": "AlreadyExists",
+                                "message": ""
+                            }
                         }
                     }
                 }
@@ -561,10 +595,70 @@
                     "description": "Unique identifier"
                 },
                 "sku": {
+                    "x-ms-client-name": "ClientNameForSku",
                     "type": "string",
                     "description": "SKU"
                 }
             }
+        },
+        "CheckNameAvailabilityInput": {
+            "type": "object",
+            "required": [
+                "name",
+                "type"
+            ],
+            "properties": {
+                "name": {
+                    "description": "The Search service name to validate. Search service names must only contain lowercase letters, digits or dashes, cannot use dash as the first two or last one characters, cannot contain consecutive dashes, and must be between 2 and 60 characters in length.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type of the resource whose name is to be validated. This value must always be 'searchServices'.",
+                    "type": "string",
+                    "enum": [
+                        "searchServices"
+                    ],
+                    "x-ms-enum": {
+                        "name": "ResourceType",
+                        "modelAsString": false
+                    }
+                }
+            },
+            "description": "Input of check name availability API.",
+            "example": {
+                "name": "your-service-name-here",
+                "type": "searchServices"
+            }
+        },
+        "CheckNameAvailabilityOutput": {
+            "type": "object",
+            "properties": {
+                "nameAvailable": {
+                    "x-ms-client-name": "IsNameAvailable",
+                    "description": "A value indicating whether the name is available.",
+                    "type": "boolean",
+                    "readOnly": true
+                },
+                "reason": {
+                    "description": "The reason why the name is not available. 'Invalid' indicates the name provided does not match the naming requirements (incorrect length, unsupported characters, etc.). 'AlreadyExists' indicates that the name is already in use and is therefore unavailable.",
+                    "type": "string",
+                    "readOnly": true,
+                    "enum": [
+                        "Invalid",
+                        "AlreadyExists"
+                    ],
+                    "x-ms-enum": {
+                        "name": "UnavailableNameReason",
+                        "modelAsString": true
+                    }
+                },
+                "message": {
+                    "description": "A message that explains why the name is invalid and provides resource naming requirements. Available only if 'Invalid' is returned in the 'reason' property.",
+                    "type": "string",
+                    "readOnly": true
+                }
+            },
+            "description": "Output of check name availability API."
         },
         "Error": {
             "type": "object",


### PR DESCRIPTION
- Added support for x-ms-client-name in definition parameters.
- For definitions used as x-ms-client-flatten, ensured that New-<Definition>Object command is not generated.
- Few minor fixes
   - Added 'Get-PSCommonParameters' to exported functions list of PSSwagger.Common.Helpers module.
   - Added property check in New-<Definition>Object command.
   - Hide verbose messages from Import-Module

Resolves #227 and #228