### PR TITLE
Use CIM cmdlets instead of WMI

### DIFF
--- a/PSSwagger/PSSwagger.Common.Helpers/PSSwagger.Common.Helpers.psm1
+++ b/PSSwagger/PSSwagger.Common.Helpers/PSSwagger.Common.Helpers.psm1
@@ -1321,7 +1321,7 @@ function Get-PSSwaggerMsi {
     )
 
     if (Test-Downlevel) {
-        return Get-MsiWithWmi -Name $Name -MaximumVersion $MaximumVersion
+        return Get-MsiWithCim -Name $Name -MaximumVersion $MaximumVersion
     } else {
         return Get-MsiWithPackageManagement -Name $Name -MaximumVersion $MaximumVersion
     }
@@ -1337,7 +1337,7 @@ function Get-PSSwaggerMsi {
 .PARAMETER  MaximumVersion
   Maximum version of MSIs to find.
 #>
-function Get-MsiWithWmi {
+function Get-MsiWithCim {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
@@ -1355,7 +1355,7 @@ function Get-MsiWithWmi {
         $filter += " AND Version <= '$MaximumVersion'"
     }
 
-    $products = Get-WmiObject -Class Win32_Product -Filter $filter
+    $products = Get-CimInstance -ClassName Win32_Product -Filter $filter
     $returnObjects = @()
     $products | ForEach-Object {
         $objectProps = @{

--- a/Tests/run-tests.ps1
+++ b/Tests/run-tests.ps1
@@ -120,7 +120,7 @@ $executeTestsCommand | Out-File pesterCommand.ps1
 
 if ($TestFramework -eq "netstandard1.7") {
     try {
-        $null = Get-WmiObject Win32_OperatingSystem
+        $null = Get-CimInstance Win32_OperatingSystem
         Write-Verbose -Message "Invoking PowerShell Core at: $powershellFolder"
         & "$powershellFolder\powershell" -command .\pesterCommand.ps1
     } catch {


### PR DESCRIPTION
Resolves #213 

Ran tests with Get-PSSwaggerMsi hardcoded to use CIM. Also made sure Get-CimInstance exists on PS4.0.