### PR TITLE
Added dependencies parameter to Initialize-PSSwaggerLocalTools

### DIFF
--- a/PSSwagger/PSSwagger.Common.Helpers/PSSwagger.Common.Helpers.psm1
+++ b/PSSwagger/PSSwagger.Common.Helpers/PSSwagger.Common.Helpers.psm1
@@ -656,10 +656,14 @@ function Initialize-PSSwaggerLocalTools {
         [Parameter(Mandatory=$false)]
         [switch]
         $AcceptBootstrap,
+
+        [Parameter(Mandatory=$false)]
+        [switch]
+        $SkipDefaultDependencies,
 		
         [Parameter(Mandatory=$false)]
         [hashtable]
-        $Dependencies
+        $AdditionalDependencies
     )
 
     $bootstrapActions = @()
@@ -669,11 +673,18 @@ function Initialize-PSSwaggerLocalTools {
     $dependenciesToDownload = @()
     $packageActionAdded = $false
     foreach ($f in $Framework) {
-        if (-not $Dependencies) {
-            $Dependencies = Get-PSSwaggerExternalDependencies -Framework $f -Azure:$Azure -RequiredVersionMap $RequiredVersionMap
+        $dependencies = @()
+        if ($AdditionalDependencies) {
+            foreach ($entry in $AdditionalDependencies.GetEnumerator()) {
+                $dependencies += $entry
+            }
         }
-        
-        foreach ($entry in $Dependencies.GetEnumerator()) {
+        if (-not $SkipDefaultDependencies) {
+            foreach ($entry in (Get-PSSwaggerExternalDependencies -Framework $f -Azure:$Azure -RequiredVersionMap $RequiredVersionMap).GetEnumerator()) {
+                $dependencies += $entry
+            }
+        }
+        foreach ($entry in $dependencies) {
             $dependency = $entry.Value
             
             $assemblyPaths = Get-PSSwaggerDependency -PackageName $dependency.PackageName -References $dependency.References -Framework $dependency.Framework -RequiredVersion $dependency.RequiredVersion -AllUsers:$AllUsers

--- a/Tests/TestUtilities.psm1
+++ b/Tests/TestUtilities.psm1
@@ -60,7 +60,7 @@ function Initialize-Test {
     if((Get-Variable -Name PSEdition -ErrorAction Ignore) -and ('Core' -eq $PSEdition)) {
         & "powershell.exe" -command "& {`$env:PSModulePath=`$env:PSModulePath_Backup;
             Import-Module (Join-Path `"$PsSwaggerPath`" `"PSSwagger.psd1`") -Force;
-            Import-Module (Join-Path `"$PsSwaggerPath`" `"PSSwagger.Common.Helpers`" | Join-Path -ChildPath `"PSSwagger.Common.Helpers.psd1`") -Force;
+            Import-Module (Join-Path `"$PsSwaggerPath`" `"PSSwagger.Common.Helpers`") -Force;
             Initialize-PSSwaggerDependencies -AllFrameworks -AcceptBootstrap -Azure:`$$UseAzureCSharpGenerator;
             New-PSSwaggerModule -SwaggerSpecPath (Join-Path -Path `"$testCaseDataLocation`" -ChildPath $TestSpecFileName) -Path "$generatedModulesPath" -Name $GeneratedModuleName -Verbose -NoAssembly -UseAzureCSharpGenerator:`$$UseAzureCSharpGenerator -ConfirmBootstrap;
         }"


### PR DESCRIPTION
Adding an option to pass in dependency map instead of hardcoding. This will be used by PSSwagger satellite modules like the JSON-RPC test server.

Also includes a random fix for core CLR test run. The test run overall is still broken though.