### PR TITLE
Fix 'Unable to find expected service client type' error for module with assembly scenario

### DIFF
--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -667,6 +667,14 @@ function ConvertTo-CsharpCode
                                                 -BootstrapConsent:`$$UserConsent ``
                                                 -TestBuild:`$$TestBuild ``
                                                 -SymbolPath $SymbolPath;
+                    if('$outAssembly') {
+                        # Load the generated assembly to extract the extended metadata
+                        `$AssemblyPath = Join-Path -Path '$clrPath' -ChildPath '$outAssembly'
+                        if(Test-Path -Path `$AssemblyPath -PathType Leaf) {
+                            Add-Type -Path `$AssemblyPath
+                        }
+                    }
+
                     Import-Module `"`$(Join-Path -Path `"$PSScriptRoot`" -ChildPath `"Paths.psm1`")` -DisableNameChecking;
                     Set-ExtendedCodeMetadata -MainClientTypeName $fullModuleName ``
                                                 -CliXmlTmpPath $cliXmlTmpPath"


### PR DESCRIPTION
# Repro steps
```powershell
PS C:\> New-PSSwaggerModule -SwaggerSpecPath .\storage.json -Name TestModuleGen2 -Path C:\temp\generatedmodule -UseAzureCsharpGenerator -Verbose

VERBOSE: Generating CSharp Code using AutoRest
VERBOSE: Invoking AutoRest with the following parameters:
VERBOSE: -Input = .\storage.json
VERBOSE: -OutputDirectory = C:\temp\generatedmodule\TestModuleGen2\0.0.1\Generated.Csharp
VERBOSE: -Namespace = Microsoft.AzureStack.Storage.Admin
VERBOSE: -AddCredentials = True
VERBOSE: -CodeGenerator = Azure.CSharp
VERBOSE: -Modeler = Swagger
VERBOSE: Generating assembly from the CSharp code
VERBOSE: Extracting metadata from generated assembly
VERBOSE: Result of assembly compilation: True
VERBOSE: Generated 'Microsoft.AzureStack.Storage.Admin.dll' assembly
Module generation failed. If no error messages follow, check the output of code metadata extraction above
Unable to find expected service client type: Microsoft.AzureStack.Storage.Admin.StorageAdminClient
At C:\code\psswagger\psswagger\PSSwagger.psm1:712 char:13
+             throw $errorMessage
+             ~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Module generati...rageAdminClient:String) [], RuntimeException
    + FullyQualifiedErrorId : Module generation failed. If no error messages follow, check the output of code metadata extraction above
Unable to find expected service client type: Microsoft.AzureStack.Storage.Admin.StorageAdminClient
```
