### PR TITLE
SwaggerUtils fix for PSSwagger publishing

### DIFF
--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -10,7 +10,7 @@
 
 Microsoft.PowerShell.Core\Set-StrictMode -Version Latest
 Import-Module (Join-Path -Path $PSScriptRoot -ChildPath Utilities.psm1)
-Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'PSSwaggerUtility')
+Import-Module -Name 'PSSwaggerUtility'
 . "$PSScriptRoot\PSSwagger.Constants.ps1" -Force
 . "$PSScriptRoot\Trie.ps1" -Force
 . "$PSScriptRoot\PSCommandVerbMap.ps1" -Force


### PR DESCRIPTION
SwaggerUtils.psm1 still had a local reference to PSSwaggerUtility. Tested by successfully importing PSSwagger from INT gallery with this fix.