### PR TITLE
Fix localization error in SwaggerUtils

### DIFF
--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -28,7 +28,7 @@ if(-not (Get-OperatingSystemInfo).IsCore)
         Add-Type -AssemblyName System.Data.Entity.Design
     }
 
-    $script:PluralizationService = [System.Data.Entity.Design.PluralizationServices.PluralizationService]::CreateService([System.Globalization.CultureInfo]::CurrentCulture)
+    $script:PluralizationService = [System.Data.Entity.Design.PluralizationServices.PluralizationService]::CreateService([System.Globalization.CultureInfo]::GetCultureInfo('en-US'))
 
     $PluralToSingularMapPath = Join-Path -Path $PSScriptRoot -ChildPath 'PluralToSingularMap.json'
     if(Test-Path -Path $PluralToSingularMapPath -PathType Leaf)


### PR DESCRIPTION
Pluralization is only supported for the English language. Importing PSSwagger fails on non-English systems - this fix enables the Pluralization service to be used on English and non-English systems.

## Original error message 
```
Ausnahme beim Aufrufen von "CreateService" mit 1 Argument(en):  "Die Kultur "Deutsch (Deutschland)" wird nicht unterstützt. Die Pluralisierung wird derzeit
nur für die englische Sprache unterstützt."
In Zeile:1 Zeichen:1
+ [System.Data.Entity.Design.PluralizationServices.PluralizationService ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : NotImplementedException
```