### PR TITLE
Ensure $oDataQuery expression is generated properly with global parameters

### DIFF
--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -941,7 +941,8 @@ function Get-ParamType
             {
                 #  #<...>/parameters/<PARAMETERNAME>
                 $GlobalParameters = $SwaggerDict['Parameters']
-                $GlobalParamDetails = $GlobalParameters[$ReferenceParts[-1]]
+                # Cloning the common parameters object so that some values can be updated without impacting other operations.
+                $GlobalParamDetails = $GlobalParameters[$ReferenceParts[-1]].Clone()
 
                 # Get the definition name of the global parameter so that 'New-<DefinitionName>Object' can be generated.
                 if($GlobalParamDetails.Type -and $GlobalParamDetails.Type -match '[.]') {


### PR DESCRIPTION
Below $oDataQuery expression is not getting generated for the swagger operations with x-ms-odata when $Filter global parameter is also referenced in other swagger operations without  x-ms-odata extension.
This is happening as we were not cloning the global parameter details when copying for the swagger operations.

```powershell
    $oDataQuery = ""
    if ($Filter) { $oDataQuery += "&`$Filter=$Filter" }
    $oDataQuery = $oDataQuery.Trim("&")    
```

Note: I have created a tracking issue for adding tests for x-ms-odata extension #306 