### PR TITLE
Remove '/langversion' from CSC.exe parameter list as 'latest' is the default language version

### DIFF
--- a/PSSwagger/PSSwaggerUtility/PSSwaggerUtility.psm1
+++ b/PSSwagger/PSSwaggerUtility/PSSwaggerUtility.psm1
@@ -806,7 +806,6 @@ function Get-CscParameters {
     $CscParameter = @(
         $SourceCodeFilePath
         '/nologo',
-        '/langversion:latest',
         '/checked',
         '/warn:3',
         '/debug:full',


### PR DESCRIPTION
Removed the langversion from CSC parameters as latest is the default language version.
**Reason**: '/langversion:latest' is not supported on all versions of CSC.exe, especially the version installed with Visual Studio.