### PR TITLE
Handle error responses in Live Test Server

### DIFF
--- a/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.ConsoleServer/CloudErrorTransform.json
+++ b/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.ConsoleServer/CloudErrorTransform.json
@@ -1,0 +1,19 @@
+﻿{
+	"type": "System.Management.Automation.ActionPreferenceStopException",
+  "transforms": [
+    {
+      "query": "select",
+      "property": "ErrorRecord",
+      "result": "System.Management.Automation.ErrorRecord"
+    },
+    {
+      "query": "select",
+      "property": "Exception",
+      "result": "Microsoft.Rest.Azure.CloudException"
+    },
+    {
+      "query": "select",
+      "property": "Body"
+    }
+  ]
+}

--- a/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.ConsoleServer/PSSwagger.LTF.ConsoleServer.csproj
+++ b/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.ConsoleServer/PSSwagger.LTF.ConsoleServer.csproj
@@ -10,9 +10,12 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="System.Management.Automation" Version="6.0.0-alpha17" />
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="Newtonsoft.JSON" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.JSON" Version="10.0.3" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="CloudErrorTransform.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="config.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.ConsoleServer/config.json
+++ b/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.ConsoleServer/config.json
@@ -1,2 +1,3 @@
 {
+  "TransformDefinitionFiles":  [ "CloudErrorTransform.json" ]
 }

--- a/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.IO.Lib/PSSwagger.LTF.IO.Lib.csproj
+++ b/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.IO.Lib/PSSwagger.LTF.IO.Lib.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net452</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.JSON" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.JSON" Version="10.0.3" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0-preview2-25405-01" />

--- a/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/LiveTestServer.cs
+++ b/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/LiveTestServer.cs
@@ -16,6 +16,7 @@ namespace PSSwagger.LTF.Lib
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
+    using Transforms;
 
     public class LiveTestServerStartParams
     {
@@ -27,9 +28,11 @@ namespace PSSwagger.LTF.Lib
         public IList<string> SpecificationPaths { get; set; }
         public LiveTestCredentialFactory CredentialFactory { get; set; }
         public ServiceTracingManager TracingManager { get; set; }
+        public IList<DynamicObjectTransform> ObjectTransforms { get; set; }
         public LiveTestServerStartParams()
         {
             this.SpecificationPaths = new List<string>();
+            this.ObjectTransforms = new List<DynamicObjectTransform>();
         }
     }
 
@@ -187,7 +190,7 @@ namespace PSSwagger.LTF.Lib
                                     }
                                     else
                                     {
-                                        response = msg.MakeResponse(commandResult, serviceTracer, this.parameters.Logger);
+                                        response = msg.MakeResponse(commandResult, serviceTracer, parameters.ObjectTransforms, this.parameters.Logger);
                                     }
                                 }
                                 catch (Exception exRequest)

--- a/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/Messages/LiveTestError.cs
+++ b/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/Messages/LiveTestError.cs
@@ -3,6 +3,9 @@
 // Licensed under the MIT license.
 namespace PSSwagger.LTF.Lib.Messages
 {
+    using Microsoft.Rest;
+    using System.Net.Http;
+
     /// <summary>
     /// Error response from test operation.
     /// </summary>
@@ -10,11 +13,7 @@ namespace PSSwagger.LTF.Lib.Messages
     {
         public long Code { get; set; }
         public string Message { get; set; }
-        public LiveTestResult Data { get; set; }
-
-        public LiveTestError()
-        {
-            this.Data = new LiveTestResult();
-        }
+        public object Data { get; set; }
+        public HttpResponseMessage HttpResponse { get; set; }
     }
 }

--- a/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/Messages/LiveTestRequest.cs
+++ b/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/Messages/LiveTestRequest.cs
@@ -11,6 +11,7 @@ namespace PSSwagger.LTF.Lib.Messages
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using Transforms;
 
     /// <summary>
     /// An Azure Live Test Framework JSON-RPC request.
@@ -28,7 +29,7 @@ namespace PSSwagger.LTF.Lib.Messages
         [JsonIgnore]
         public bool HttpResponse { get; set; }
 
-        public LiveTestResponse MakeResponse(CommandExecutionResult commandResult, IServiceTracer tracer, Logger logger)
+        public LiveTestResponse MakeResponse(CommandExecutionResult commandResult, IServiceTracer tracer, IList<DynamicObjectTransform> transforms, Logger logger)
         {
             LiveTestResponse response = MakeBaseResponse();
             if (commandResult.HadErrors)
@@ -41,7 +42,31 @@ namespace PSSwagger.LTF.Lib.Messages
 
                 response.Error = new LiveTestError();
                 response.Error.Code = InvalidRequest;
-                response.Error.Data = GetLiveTestResult(commandResult.Errors, tracer);
+                List<object> errors = new List<object>();
+                foreach (object originalError in commandResult.Errors)
+                {
+                    errors.AddRange(TransformObject(originalError, transforms));
+                }
+
+                response.Error.Data = errors.Count == 0 ? null : errors.Count == 1 ? errors[0] : errors;
+                if (this.HttpResponse)
+                {
+                    HttpResponseMessage responseMessage = tracer.HttpResponses.LastOrDefault();
+                    if (responseMessage != null)
+                    {
+                        // Kill the Content property - doesn't work with Newtonsoft.Json serialization
+                        HttpResponseMessage clonedMessage = new HttpResponseMessage(responseMessage.StatusCode);
+                        foreach (var header in responseMessage.Headers)
+                        {
+                            clonedMessage.Headers.Add(header.Key, header.Value);
+                        }
+
+                        clonedMessage.ReasonPhrase = responseMessage.ReasonPhrase;
+                        clonedMessage.RequestMessage = responseMessage.RequestMessage;
+                        clonedMessage.Version = responseMessage.Version;
+                        response.Error.HttpResponse = clonedMessage;
+                    }
+                }
             }
             else
             {
@@ -50,7 +75,13 @@ namespace PSSwagger.LTF.Lib.Messages
                     logger.LogAsync("Command executed successfully.");
                 }
 
-                response.Result = GetLiveTestResult(commandResult.Results, tracer);
+                List<object> results = new List<object>();
+                foreach (object originalResult in commandResult.Results)
+                {
+                    results.AddRange(TransformObject(originalResult, transforms));
+                }
+
+                response.Result = GetLiveTestResult(results, tracer);
             }
 
             return response;
@@ -61,8 +92,30 @@ namespace PSSwagger.LTF.Lib.Messages
             LiveTestResponse response = MakeBaseResponse();
             response.Error = new LiveTestError();
             response.Error.Code = errorCode;
-            response.Error.Data.Response = ex;
+            response.Error.Data = ex;
             return response;
+        }
+
+        private IEnumerable<object> TransformObject(object obj, IList<DynamicObjectTransform> transforms)
+        {
+            bool transformed = false;
+            foreach (object result in transforms.Where(t => t.CanTransform(obj)).SelectMany(t => t.Transform(obj)))
+            {
+                transformed = true;
+                IEnumerable<object> transformedResults = TransformObject(result, transforms);
+                if (transformedResults != null)
+                {
+                    foreach (object innerResult in transformedResults)
+                    {
+                        yield return innerResult;
+                    }
+                }
+            }
+
+            if (!transformed)
+            {
+                yield return obj;
+            }
         }
 
         private LiveTestResult GetLiveTestResult(IEnumerable<object> resultsEnumerable, IServiceTracer tracer)

--- a/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/PSSwagger.LTF.Lib.csproj
+++ b/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/PSSwagger.LTF.Lib.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net452</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.JSON" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.JSON" Version="10.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PSSwagger.LTF.IO.Lib\PSSwagger.LTF.IO.Lib.csproj" />

--- a/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/Transforms/DynamicObjectTransform.cs
+++ b/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/Transforms/DynamicObjectTransform.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+// Licensed under the MIT license.
+namespace PSSwagger.LTF.Lib.Transforms
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Defines transform steps for a single type.
+    /// </summary>
+    public class DynamicObjectTransform
+    {
+        /// <summary>
+        /// Gets or sets the type to apply transform to.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ordered list of transforms to apply to this type.
+        /// </summary>
+        public DynamicObjectTransformDefinition[] Transforms { get; set; }
+
+        /// <summary>
+        /// Checks if <paramref name="obj"/> exactly matches the Type property.
+        /// </summary>
+        /// <param name="obj">Object to check. Can be null.</param>
+        /// <returns>False if null or <paramref name="obj"/>.GetType().FullName does not match this.Type; True otherwise.</returns>
+        public bool CanTransform(object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+
+            return obj.GetType().FullName.Equals(this.Type, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Transform the given object into one or more objects. For multi-step transforms, all steps should define an expected output type. Otherwise, the client should re-query all transformers.
+        /// </summary>
+        /// <param name="obj">Object to transform. Can be null.</param>
+        /// <returns>Null if <paramref name="obj"/> is null. Otherwise, returns the result of valid transforms.</returns>
+        public IEnumerable<object> Transform(object obj)
+        {
+            if (this.Transforms != null)
+            {
+                List<object> toTransform = new List<object>();
+                List<object> transformResult = new List<object>();
+                List<object> swap = null;
+                toTransform.Add(obj);
+                foreach (DynamicObjectTransformDefinition definition in this.Transforms)
+                {
+                    transformResult.Clear();
+                    foreach (object transformObject in toTransform)
+                    {
+                        IEnumerable<object> newObjects = definition.Transform(transformObject);
+                        if (!String.IsNullOrEmpty(definition.Result))
+                        {
+                            newObjects = newObjects.Where(o => o.GetType().FullName.Equals(definition.Result, StringComparison.OrdinalIgnoreCase));
+                        }
+
+                        transformResult.AddRange(newObjects);
+                    }
+                    
+                    // Nothing to transform to the next phase, just return the previous phase
+                    if (transformResult.Count == 0)
+                    {
+                        return toTransform;
+                    }
+
+                    swap = toTransform;
+                    toTransform = transformResult;
+                    transformResult = swap;
+                }
+
+                // The result of the last phase will be in toTransform
+                return toTransform;
+            }
+
+            return null;
+        }
+    }
+}

--- a/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/Transforms/DynamicObjectTransformDefinition.cs
+++ b/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/Transforms/DynamicObjectTransformDefinition.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+// Licensed under the MIT license.
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace PSSwagger.LTF.Lib.Transforms
+{
+    /// <summary>
+    /// Defines a single transform step.
+    /// </summary>
+    public class DynamicObjectTransformDefinition
+    {
+        /// <summary>
+        /// Gets or sets the transform type. Supported: 'select'
+        /// </summary>
+        public string Query { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property to select. Valid for query types: 'select'
+        /// </summary>
+        public string Property { get; set; }
+
+        /// <summary>
+        /// Gets or sets the result type. Optional. If defined, subsequent transforms will only take place if the output type matches this type. This optimizes multi-step transforms.
+        /// </summary>
+        public string Result { get; set; }
+
+        public IEnumerable<object> Transform(object obj)
+        {
+            if (!string.IsNullOrEmpty(this.Query))
+            {
+                switch (this.Query.ToLowerInvariant())
+                {
+                    case "select":
+                        yield return Select(obj);
+                        break;
+                }
+            }
+        }
+
+        private object Select(object obj)
+        {
+            PropertyInfo pi = obj.GetType().GetProperty(this.Property);
+            if (pi != null)
+            {
+                return pi.GetValue(obj);
+            }
+
+            return null;
+        }
+    }
+}

--- a/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/vs-csproj/PSSwagger.LTF.Lib.csproj
+++ b/PSSwagger.LiveTestFramework/src/PSSwagger.LTF.Lib/vs-csproj/PSSwagger.LTF.Lib.csproj
@@ -94,6 +94,9 @@
     <Compile Include="..\PostProcessors\*.cs">
       <Link>PostProcessors\%(FileName).cs</Link>
     </Compile>
+    <Compile Include="..\Transforms\*.cs">
+      <Link>Transforms\%(FileName).cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
Batch of fixes required to get error handling correct for the test server. At this point Azure Batch E2E tests pass.

- Update Newtonsoft.Json to 10.0.3 as 10.0.1 has a bug with respect to deserializing the ```CloudError``` type
- Unwrap expected exceptions into the final ```CloudError``` object - the framework provided is used for transforming any result, including other error types we might run into
- When returning an error response, include the last ```HttpResponseMessage```, if any. Remove the ```Content``` property as it's not serializable. However, sometimes the ```HttpResponseMessage``` is disposed so ```response.Content = null``` doesn't always work. To get around that issue, we manually create a clone.
- The error response schema in the library doesn't match the specification - fix our model to match the library