### PR TITLE
Change warninglevel to 1 for generating assembly for Azure Swagger specs

### DIFF
--- a/PSSwagger/PSCommandVerbMap.ps1
+++ b/PSSwagger/PSCommandVerbMap.ps1
@@ -9,134 +9,135 @@
 #########################################################################################
 $script:PSCommandVerbMap = @{
 
-    Access = 'Get'
-    List = 'Get'
-    Cat = 'Get'
-    Type = 'Get'
-    Dir = 'Get'
-    Obtain = 'Get'
-    Dump = 'Get'
-    Acquire = 'Get'
-    Examine = 'Get'
-    Suggest = 'Get'
+    Access         = 'Get'
+    List           = 'Get'
+    Cat            = 'Get'
+    Type           = 'Get'
+    Dir            = 'Get'
+    Obtain         = 'Get'
+    Dump           = 'Get'
+    Acquire        = 'Get'
+    Examine        = 'Get'
+    Suggest        = 'Get'
 
-    Create = 'New'
-    Generate = 'New'
-    Allocate = 'New'
-    Provision = 'New'
-    Make = 'New'
+    Create         = 'New'
+    Generate       = 'New'
+    Allocate       = 'New'
+    Provision      = 'New'
+    Make           = 'New'
 
     CreateOrUpdate = 'New,Set'
-    Failover = 'Set'
-    Assign = 'Set'
-    Configure = 'Set'
+    Failover       = 'Set'
+    Assign         = 'Set'
+    Configure      = 'Set'
 
-    Activate = 'Initialize'
+    Activate       = 'Initialize'
 
-    Build = 'Build'
-    Compile = 'Build'
+    Build          = 'Build'
+    Compile        = 'Build'
 
-    Deploy = 'Deploy'
+    Deploy         = 'Deploy'
 
-    Apply = 'Add'
-    Append = 'Add'
-    Attach = 'Add'
-    Concatenate = 'Add'
-    Insert = 'Add'
+    Apply          = 'Add'
+    Append         = 'Add'
+    Attach         = 'Add'
+    Concatenate    = 'Add'
+    Insert         = 'Add'
 
-    Delete = 'Remove'
-    Cut = 'Remove'
-    Dispose = 'Remove'
-    Discard = 'Remove'
+    Delete         = 'Remove'
+    Cut            = 'Remove'
+    Dispose        = 'Remove'
+    Discard        = 'Remove'
     
-    Generalize = 'Reset'
+    Generalize     = 'Reset'
 
-    Patch = 'Update'
-    Refresh = 'Update'
-    Regenerate = 'Update' # Alternatives: Redo, New, Reset
-    Reprocess = "Update" # Alternatives: Redo
-    Upgrade = 'Update'
-    Reimage = 'Update' # Alternatives: Format, Reset
+    Patch          = 'Update'
+    Refresh        = 'Update'
+    Regenerate     = 'Update' # Alternatives: Redo, New, Reset
+    Reprocess      = "Update" # Alternatives: Redo
+    Upgrade        = 'Update'
+    Reimage        = 'Update' # Alternatives: Format, Reset
 
-    Validate = 'Test'
-    Check = 'Test'
-    Analyze = 'Test' 
-    Is = 'Test'
-    Evaluate = 'Test' # Alternatives: Invoke
+    Validate       = 'Test'
+    Check          = 'Test'
+    Verify         = 'Test'
+    Analyze        = 'Test' 
+    Is             = 'Test'
+    Evaluate       = 'Test' # Alternatives: Invoke
 
-    Power = 'Start'
-    PowerOn = 'Start'
-    Run = 'Start' # Alternatives: Invoke
-    Trigger = 'Start'
+    Power          = 'Start'
+    PowerOn        = 'Start'
+    Run            = 'Start' # Alternatives: Invoke
+    Trigger        = 'Start'
 
-    Pause = 'Suspend'
+    Pause          = 'Suspend'
     
-    Cancel = 'Stop'
-    PowerOff = 'Stop'
-    End = 'Stop'
-    Shutdown = 'Stop'
+    Cancel         = 'Stop'
+    PowerOff       = 'Stop'
+    End            = 'Stop'
+    Shutdown       = 'Stop'
 
-    Reboot = 'Restart'
-    ForceReboot = 'Restart'
+    Reboot         = 'Restart'
+    ForceReboot    = 'Restart'
 
-    Finish = 'Complete'
+    Finish         = 'Complete'
 
-    Wipe = 'Clear'
-    Purge = 'Clear' # Alternatives: Remove
-    Flush = 'Clear'
-    Erase = 'Clear'
-    Unmark = 'Clear'
-    Unset = 'Clear'
-    Nullify = 'Clear'
+    Wipe           = 'Clear'
+    Purge          = 'Clear' # Alternatives: Remove
+    Flush          = 'Clear'
+    Erase          = 'Clear'
+    Unmark         = 'Clear'
+    Unset          = 'Clear'
+    Nullify        = 'Clear'
 
-    Recover = 'Restore'
-    Undelete = 'Restore'
+    Recover        = 'Restore'
+    Undelete       = 'Restore'
 
-    Synchronize = 'Sync'
-    Synch = 'Sync'
+    Synchronize    = 'Sync'
+    Synch          = 'Sync'
 
-    Load = 'Import'
+    Load           = 'Import'
 
-    Capture = 'Export' # Alternatives: Trace
+    Capture        = 'Export' # Alternatives: Trace
 
-    Migrate = 'Move' # Alternatives: Export
-    Transfer = 'Move'
-    Name = 'Move'
+    Migrate        = 'Move' # Alternatives: Export
+    Transfer       = 'Move'
+    Name           = 'Move'
 
-    Change = 'Rename'
+    Change         = 'Rename'
 
-    Swap = 'Switch' # Alternatives: Move
+    Swap           = 'Switch' # Alternatives: Move
     
-    Execute = 'Invoke'
+    Execute        = 'Invoke'
 
-    Discover = 'Find' # Alternatives: Search
-    Locate = 'Find'
+    Discover       = 'Find' # Alternatives: Search
+    Locate         = 'Find'
 
-    Release = 'Publish' # Alternatives: Clear, Unlock
+    Release        = 'Publish' # Alternatives: Clear, Unlock
 
-    Resubmit = 'Submit'
+    Resubmit       = 'Submit'
     
-    Duplicate = 'Copy'
-    Clone = 'Copy'
-    Replicate = 'Copy'
+    Duplicate      = 'Copy'
+    Clone          = 'Copy'
+    Replicate      = 'Copy'
     
-    Into = 'Enter'    
+    Into           = 'Enter'    
    
-    Combine = 'Join'
-    Unite = 'Join'
-    Associate = 'Join'
+    Combine        = 'Join'
+    Unite          = 'Join'
+    Associate      = 'Join'
     
-    Restrict = 'Lock'
-    Secure = 'Lock'
+    Restrict       = 'Lock'
+    Secure         = 'Lock'
     
-    Unrestrict = 'Unlock'
-    Unsecure = 'Unlock'
+    Unrestrict     = 'Unlock'
+    Unsecure       = 'Unlock'
     
-    Display = 'Show'
-    Produce = 'Show'
+    Display        = 'Show'
+    Produce        = 'Show'
     
-    Bypass = 'Skip'
-    Jump = 'Skip'
+    Bypass         = 'Skip'
+    Jump           = 'Skip'
     
-    Separate = 'Split'
+    Separate       = 'Split'
 }

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -927,7 +927,7 @@ function ConvertTo-CsharpCode
 
         # In some cases, PSCore doesn't inherit this process's PSModulePath
         $command = @"
-		    `$env:PSModulePath = `"$env:PSModulePath`";
+            `$env:PSModulePath += ';$env:PSModulePath'
             `$AddPSSwaggerClientType_params = @{
                 OutputAssemblyName                             = '$outAssembly'
                 ClrPath                                        = '$clrPath'
@@ -938,7 +938,6 @@ function ConvertTo-CsharpCode
                 CodeCreatedByAzureGenerator                    = `$$codeCreatedByAzureGenerator
                 BootstrapConsent                               = `$$UserConsent
             }
-            `$env:PSModulePath += ';$env:PSModulePath'
             PSSwaggerUtility\Add-PSSwaggerClientType @AddPSSwaggerClientType_params
 "@
         $success = & "$PowerShellCorePath" -command "& {$command}"

--- a/PSSwagger/PSSwaggerUtility/PSSwaggerUtility.psm1
+++ b/PSSwagger/PSSwaggerUtility/PSSwaggerUtility.psm1
@@ -733,7 +733,7 @@ function Get-AddTypeParameters {
     if (-not (Get-OperatingSystemInfo).IsCore) {
         $AddTypeParams['Path'] = $SourceCodeFilePath
         $compilerParameters = New-Object -TypeName System.CodeDom.Compiler.CompilerParameters
-        $compilerParameters.WarningLevel = 3
+        $compilerParameters.WarningLevel = 1
         $compilerParameters.CompilerOptions = '/debug:full'
         if ($TestBuild) {
             $compilerParameters.IncludeDebugInformation = $true
@@ -807,7 +807,7 @@ function Get-CscParameters {
         $SourceCodeFilePath
         '/nologo',
         '/checked',
-        '/warn:3',
+        '/warn:1',
         '/debug:full',
         '/platform:anycpu',
         "/target:$TargetType"


### PR DESCRIPTION
Changed warning level to 1 for generating assembly for Azure Swagger specs. Resolves below error.
```powershell
Generating module for 'C:\temp\AzureSwaggerSpecs\SwaggerSpecs\monitor\autoscale_API.json'.
PSSwaggerUtility\Add-PSSwaggerClientType : C:\temp\AzureSwaggerSpecs\AzModules\symbols\Azmonitor\0.0.1\Generated.Microsoft.PowerShell.Azmonitor.v001.cs(433,23): warning CS0108: 'ActivityLogAlertLeafCondition.Equals' hides inherited member 'object.
the new keyword if hiding was intended.
At C:\Code\PSSwagger\PSSwagger\PSSwagger.psm1:900 char:14
+ ...    if(-not (PSSwaggerUtility\Add-PSSwaggerClientType @AddPSSwaggerCli ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : SOURCE_CODE_ERROR,Add-PSSwaggerClientType

ConvertTo-CsharpCode : Unable to generate 'Microsoft.PowerShell.Azmonitor.v001.dll' assembly
At C:\Code\PSSwagger\PSSwagger\PSSwagger.psm1:545 char:37
+ ... lyGenerationResult = ConvertTo-CsharpCode @ConvertToCsharpCode_params
+                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : UnableToGenerateAssembly,ConvertTo-CsharpCode
```

Minor additional changes
- Fixed an issue for setting $env:PSModulePath to compile coreclr binary
- Added verb mapping for 'Verify' --> 'Test'.