### PR TITLE
Rename IsOSX to IsMacOS after breaking change in PowerShell 6.0.0-beta.7 to fix #333

### DIFF
--- a/PSSwagger.LiveTestFramework/build/PSSwagger.LiveTestFramework.Build.psm1
+++ b/PSSwagger.LiveTestFramework/build/PSSwagger.LiveTestFramework.Build.psm1
@@ -252,15 +252,15 @@ function Install-Dotnet {
     $osInfo = PSSwaggerUtility\Get-OperatingSystemInfo
     $obtainUrl = "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain"
 
-    # Install for Linux and OS X
-    if ($osInfo.IsLinux -or $osInfo.IsOSX) {
+    # Install for Linux and Mac OS
+    if ($osInfo.IsLinux -or $osInfo.IsMacOS) {
         $LinuxInfo = Get-Content /etc/os-release -Raw | ConvertFrom-StringData
         $IsUbuntu = $LinuxInfo.ID -match 'ubuntu'
 
         # Uninstall all previous dotnet packages
         $uninstallScript = if ($IsUbuntu) {
             "dotnet-uninstall-debian-packages.sh"
-        } elseif ($osInfo.IsOSX) {
+        } elseif ($osInfo.IsMacOS) {
             "dotnet-uninstall-pkgs.sh"
         }
 

--- a/PSSwagger.LiveTestFramework/test/PSSwagger.LiveTestFramework.Tests.psm1
+++ b/PSSwagger.LiveTestFramework/test/PSSwagger.LiveTestFramework.Tests.psm1
@@ -157,14 +157,14 @@ function Install-Dotnet {
     $obtainUrl = "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain"
 
     # Install for Linux and OS X
-    if ($osInfo.IsLinux -or $osInfo.IsOSX) {
+    if ($osInfo.IsLinux -or $osInfo.IsMacOS) {
         $LinuxInfo = Get-Content /etc/os-release -Raw | ConvertFrom-StringData
         $IsUbuntu = $LinuxInfo.ID -match 'ubuntu'
 
         # Uninstall all previous dotnet packages
         $uninstallScript = if ($IsUbuntu) {
             "dotnet-uninstall-debian-packages.sh"
-        } elseif ($osInfo.IsOSX) {
+        } elseif ($osInfo.IsMacOS) {
             "dotnet-uninstall-pkgs.sh"
         }
 

--- a/PSSwagger/PSSwaggerUtility/PSSwaggerUtility.psm1
+++ b/PSSwagger/PSSwaggerUtility/PSSwaggerUtility.psm1
@@ -250,13 +250,13 @@ function Start-PSSwaggerJobHelper
 
 <#
 .DESCRIPTION
-  Gets operating system information. Returns an object with the following boolean properties: IsCore, IsLinux, IsWindows, IsOSX, IsNanoServer, IsIoT
+  Gets operating system information. Returns an object with the following boolean properties: IsCore, IsLinux, IsWindows, IsMacOS, IsNanoServer, IsIoT
 #>
 function Get-OperatingSystemInfo {
     $info = @{
         IsCore = $false
         IsLinux = $false
-        IsOSX = $false
+        IsMacOS = $false
         IsWindows = $false
         IsNanoServer = $false
         IsIoT = $false
@@ -265,7 +265,7 @@ function Get-OperatingSystemInfo {
     if ('System.Management.Automation.Platform' -as [Type]) {
         $info.IsCore = [System.Management.Automation.Platform]::IsCoreCLR
         $info.IsLinux = [System.Management.Automation.Platform]::IsLinux
-        $info.IsOSX = [System.Management.Automation.Platform]::IsOSX
+        $info.IsMacOS = [System.Management.Automation.Platform]::IsMacOS
         $info.IsWindows = [System.Management.Automation.Platform]::IsWindows
         $info.IsNanoServer = [System.Management.Automation.Platform]::IsNanoServer
         $info.IsIoT = [System.Management.Automation.Platform]::IsIoT

--- a/Tests/PSSwagger.Unit.Tests.ps1
+++ b/Tests/PSSwagger.Unit.Tests.ps1
@@ -73,7 +73,7 @@ Describe "PSSwagger Unit Tests" -Tag @('BVT', 'DRT', 'UnitTest', 'P0') {
                 return @{
                     IsCore = $true
                     IsLinux = $true
-                    IsOSX = $false
+                    IsMacOS = $false
                     IsWindows = $false
                 }
             }
@@ -120,7 +120,7 @@ Describe "PSSwagger Unit Tests" -Tag @('BVT', 'DRT', 'UnitTest', 'P0') {
                 return @{
                     IsCore = $true
                     IsLinux = $true
-                    IsOSX = $false
+                    IsMacOS = $false
                     IsWindows = $false
                 }
             }
@@ -161,7 +161,7 @@ Describe "PSSwagger Unit Tests" -Tag @('BVT', 'DRT', 'UnitTest', 'P0') {
                 return @{
                     IsCore = $true
                     IsLinux = $false
-                    IsOSX = $false
+                    IsMacOS = $false
                     IsWindows = $true
                 }
             }


### PR DESCRIPTION
As described in #333 $IsOSX was renamed to $IsMacOS. This pull request makes the necessary changes in PSSwagger.