### PR TITLE
Add support for AdditionalProperties Json schema with array type

### DIFF
--- a/PSSwagger/Definitions.psm1
+++ b/PSSwagger/Definitions.psm1
@@ -387,12 +387,27 @@ function Get-DefinitionParameterType
                 if((Get-Member -InputObject $ParameterJsonObject.AdditionalProperties -Name 'Type') -and
                    ($ParameterJsonObject.AdditionalProperties.Type -eq 'array'))
                 {
-                    if((Get-Member -InputObject $ParameterJsonObject.AdditionalProperties -Name 'Items') -and
-                       (Get-Member -InputObject $ParameterJsonObject.AdditionalProperties.Items -Name 'Type') -and
-                       $ParameterJsonObject.AdditionalProperties.Items.Type)
-                    { 
-                        $ItemsType = Get-PSTypeFromSwaggerObject -JsonObject $ParameterJsonObject.AdditionalProperties.Items
-                        $ParameterType = "System.Collections.Generic.Dictionary[[string],[System.Collections.Generic.List[$ItemsType]]]"
+                    if(Get-Member -InputObject $ParameterJsonObject.AdditionalProperties -Name 'Items')
+                    {
+                        if((Get-Member -InputObject $ParameterJsonObject.AdditionalProperties.Items -Name 'Type') -and
+                           $ParameterJsonObject.AdditionalProperties.Items.Type)
+                        { 
+                            $ItemsType = Get-PSTypeFromSwaggerObject -JsonObject $ParameterJsonObject.AdditionalProperties.Items
+                            $ParameterType = "System.Collections.Generic.Dictionary[[string],[System.Collections.Generic.List[$ItemsType]]]"
+                        }
+                        elseif((Get-Member -InputObject $ParameterJsonObject.AdditionalProperties.Items -Name '$ref') -and
+                               $ParameterJsonObject.AdditionalProperties.Items.'$ref')
+                        {
+                            $ReferenceTypeValue = $ParameterJsonObject.AdditionalProperties.Items.'$ref'
+                            $ReferenceTypeName = Get-CSharpModelName -Name $ReferenceTypeValue.Substring( $( $ReferenceTypeValue.LastIndexOf('/') ) + 1 )
+                            $ItemsType = $DefinitionTypeNamePrefix + "$ReferenceTypeName"
+                            $ParameterType = "System.Collections.Generic.Dictionary[[string],[System.Collections.Generic.List[$ItemsType]]]"
+                        }
+                        else
+                        {
+                            $Message = $LocalizedData.UnsupportedSwaggerProperties -f ('ParameterJsonObject', $($ParameterJsonObject | Out-String))
+                            Write-Warning -Message $Message
+                        }
                     }
                     else
                     {

--- a/PSSwagger/Definitions.psm1
+++ b/PSSwagger/Definitions.psm1
@@ -383,6 +383,29 @@ function Get-DefinitionParameterType
                     Write-Warning -Message $Message
                 }
             }
+            elseif($ParameterJsonObject.Type -eq 'string') {
+                if((Get-Member -InputObject $ParameterJsonObject.AdditionalProperties -Name 'Type') -and
+                   ($ParameterJsonObject.AdditionalProperties.Type -eq 'array'))
+                {
+                    if((Get-Member -InputObject $ParameterJsonObject.AdditionalProperties -Name 'Items') -and
+                       (Get-Member -InputObject $ParameterJsonObject.AdditionalProperties.Items -Name 'Type') -and
+                       $ParameterJsonObject.AdditionalProperties.Items.Type)
+                    { 
+                        $ItemsType = Get-PSTypeFromSwaggerObject -JsonObject $ParameterJsonObject.AdditionalProperties.Items
+                        $ParameterType = "System.Collections.Generic.Dictionary[[string],[System.Collections.Generic.List[$ItemsType]]]"
+                    }
+                    else
+                    {
+                        $Message = $LocalizedData.UnsupportedSwaggerProperties -f ('ParameterJsonObject', $($ParameterJsonObject | Out-String))
+                        Write-Warning -Message $Message
+                    }
+                }
+                else
+                {
+                    $Message = $LocalizedData.UnsupportedSwaggerProperties -f ('ParameterJsonObject', $($ParameterJsonObject | Out-String))
+                    Write-Warning -Message $Message
+                }
+            }
             else {
                 $Message = $LocalizedData.UnsupportedSwaggerProperties -f ('ParameterJsonObject', $($ParameterJsonObject | Out-String))
                 Write-Warning -Message $Message

--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -987,6 +987,29 @@ function Get-ParamType
                     Write-Warning -Message $Message
                 }
             }
+            elseif($ParameterJsonObject.Type -eq 'string') {
+                if((Get-Member -InputObject $ParameterJsonObject.AdditionalProperties -Name 'Type') -and
+                   ($ParameterJsonObject.AdditionalProperties.Type -eq 'array'))
+                {
+                    if((Get-Member -InputObject $ParameterJsonObject.AdditionalProperties -Name 'Items') -and
+                       (Get-Member -InputObject $ParameterJsonObject.AdditionalProperties.Items -Name 'Type') -and
+                       $ParameterJsonObject.AdditionalProperties.Items.Type)
+                    { 
+                        $ItemsType = Get-PSTypeFromSwaggerObject -JsonObject $ParameterJsonObject.AdditionalProperties.Items
+                        $paramType = "System.Collections.Generic.Dictionary[[string],[System.Collections.Generic.List[$ItemsType]]]"
+                    }
+                    else
+                    {
+                        $Message = $LocalizedData.UnsupportedSwaggerProperties -f ('ParameterJsonObject', $($ParameterJsonObject | Out-String))
+                        Write-Warning -Message $Message
+                    }
+                }
+                else
+                {
+                    $Message = $LocalizedData.UnsupportedSwaggerProperties -f ('ParameterJsonObject', $($ParameterJsonObject | Out-String))
+                    Write-Warning -Message $Message
+                }
+            }
             else {
                 $Message = $LocalizedData.UnsupportedSwaggerProperties -f ('ParameterJsonObject', $($ParameterJsonObject | Out-String))
                 Write-Warning -Message $Message

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -398,6 +398,19 @@ Describe "ParameterTypes tests" -Tag @('ParameterTypes','ScenarioTest') {
             $HelpInfo2.Description.Text | Should BeExactly $ExpectedText
             $HelpInfo2.Synopsis | Should BeExactly $ExpectedText
         }
+
+        It 'Test parameter types with array of items in AdditionalProperties json schema' {
+            $ModuleName = 'Generated.ParamTypes.Module'
+            $ev = $null
+            $null = Get-Command -Module $ModuleName -Syntax -ErrorVariable ev
+            $ev | Should BeNullOrEmpty
+
+            $OperationCommandInfo = Get-Command -name Get-EffectiveNetworkSecurityGroup -Module $ModuleName
+            $OperationCommandInfo.Parameters.OperationTagMap.ParameterType.ToString() | Should BeExactly 'System.Collections.Generic.IDictionary`2[System.String,System.Collections.Generic.IList`1[System.String]]'
+            
+            $NewObjectCommandInfo = Get-Command -Name New-EffectiveNetworkSecurityGroupObject -Module $ModuleName
+            $NewObjectCommandInfo.Parameters.TagMap.ParameterType.ToString() | Should BeExactly 'System.Collections.Generic.Dictionary`2[System.String,System.Collections.Generic.List`1[System.String]]'
+        }
     }
 
     AfterAll {

--- a/Tests/data/ParameterTypes/ParameterTypesSpec.json
+++ b/Tests/data/ParameterTypes/ParameterTypesSpec.json
@@ -298,6 +298,58 @@
                     }
                 }
             }
+        },
+        "/PathWithEffectiveNetworkSecurityGroup": {
+            "get": {
+                "summary": "List all dinosaurs matching parameters",
+                "operationId": "EffectiveNetworkSecurityGroup_Get",
+                "description": "List all dinosaurs matching parameters",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    },
+                    {
+                        "$ref": "#/parameters/SubscriptionIdParameter"
+                    },
+                    {
+                        "name": "OperationTagMap",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "description": "List of IP Addresses within the tag (key)"
+                        },
+                        "description": "Mapping of tags to list of IP Addresses included within the tag."
+                    },
+                    {
+                        "name": "EffectiveNetworkSecurityGroup",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/EffectiveNetworkSecurityGroup"
+                        },
+                        "description": "Group filtering parameters."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Namespace"
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -538,6 +590,26 @@
                 }
             },
             "description": "The response of the List Namespace operation."
+        },
+        "EffectiveNetworkSecurityGroup": {
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Unique identifier"
+                },
+                "tagMap": {
+                    "type": "string",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of IP Addresses within the tag (key)"
+                    },
+                    "description": "Mapping of tags to list of IP Addresses included within the tag."
+                }
+            },
+            "description": "Effective network security group."
         }
     },
     "parameters": {


### PR DESCRIPTION
Added support for AdditionalProperties Json schema with array type.

```json
"type": "string",
"additionalProperties": {
    "type": "array",
    "items": {
        "type": "string"
    }
}
```
Current warning message for Azure Network service swagger spec.
```powershell
Generating module for 'C:\temp\AzureSwaggerSpecs\SwaggerSpecs\network\applicationGateway.json'.
WARNING: 'ParameterJsonObject' has unsupported properties.
type   additionalProperties                                                         description
----   --------------------                                                         -----------
string @{type=array; items=; description=List of IP Addresses within the tag (key)} Mapping of tags to list of IP Addresses included within the tag.

```