### PR TITLE
New-ServiceClient error on custom host

### DIFF
--- a/PSSwagger/New-ServiceClient.ps1
+++ b/PSSwagger/New-ServiceClient.ps1
@@ -85,7 +85,8 @@ function New-ServiceClient {
     $Client = New-Object -TypeName $FullClientTypeName -ArgumentList $ClientArgumentList
 
     if ($HostOverrideCommand) {
-        $Client.BaseUri = Invoke-Command -ScriptBlock [scriptblock]::Create($HostOverrideCommand)
+        [scriptblock]$HostOverrideCommand = [scriptblock]::Create($HostOverrideCommand)
+        $Client.BaseUri = Invoke-Command -ScriptBlock $HostOverrideCommand
     }
 
     if ($GlobalParameterHashtable) {


### PR DESCRIPTION
When calling using custom host I get the error:

```
PSInvalidCastException: Cannot convert the "[scriptblock]::Create" value of type "System.String" to type "System.Management.Automation.ScriptBlock".
ParameterBindingException: Cannot bind parameter 'ScriptBlock'. Cannot convert the "[scriptblock]::Create" value of type "System.String" to type "System.Management.Automation.ScriptBlock".
at New-ServiceClient, C:\PS\Module\Azs.Gallery.Admin\0.1.0\New-ServiceClient.ps1: line 96
at Get-GalleryOperationList<Process>, C:\PS\Module\Azs.Gallery.Admin\0.1.0\Generated.PowerShell.Commands\SwaggerPathCommands\Get-GalleryOperationList.ps1: line 50
at <ScriptBlock>, C:\PS\Tests\src\Operation.Tests.ps1: line 56
```

Apparently the call

```
        $Client.BaseUri = Invoke-Command -ScriptBlock [scriptblock]::Create($HostOverrideCommand)
```

does not correctly convert **this** into a scriptblock

[scriptblock]::Create($HostOverrideCommand)