### PR TITLE
Add 'NoVersionFolder' switch on New-PSSwaggerModule to not create the version folder

### DIFF
--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -72,6 +72,9 @@ Microsoft.PowerShell.Utility\Import-LocalizedData  LocalizedData -filename PSSwa
 .PARAMETER  Version
     Version of the generated PowerShell module.
 
+.PARAMETER  NoVersionFolder
+    Switch to not create the version folder under the generated module folder.
+
 .PARAMETER  DefaultCommandPrefix
     Prefix value to be prepended to cmdlet noun or to cmdlet name without verb.
 
@@ -162,6 +165,10 @@ function New-PSSwaggerModule
         [Parameter(Mandatory = $false)]
         [Version]
         $Version = '0.0.1',
+
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $NoVersionFolder,
 
         [Parameter(Mandatory = $false)]
         [string]
@@ -449,7 +456,7 @@ function New-PSSwaggerModule
     
     $nameSpace = $swaggerDict['info'].NameSpace
     $models = $swaggerDict['info'].Models
-    if($PSVersionTable.PSVersion -lt '5.0.0') {
+    if($NoVersionFolder -or $PSVersionTable.PSVersion -lt '5.0.0') {
         if (-not $outputDirectory.EndsWith($Name, [System.StringComparison]::OrdinalIgnoreCase)) {
             $outputDirectory = Join-Path -Path $outputDirectory -ChildPath $Name
             $SymbolPath = Join-Path -Path $SymbolPath -ChildPath $Name

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -1142,3 +1142,31 @@ Describe "Output type scenario tests" -Tag @('OutputType','ScenarioTest')  {
         $CommandInfo.OutputType.Type.ToString() | Should BeExactly 'System.String'
     }
 }
+
+Describe 'New-PSSwaggerModule cmdlet parameter tests' -Tag @('CmdletParameterTest','ScenarioTest')  {
+    BeforeAll {
+        $ModuleName = 'Generated.Module.NoVersionFolder'
+        $SwaggerSpecPath = Join-Path -Path $PSScriptRoot -ChildPath 'Data' | Join-Path -ChildPath 'AzureExtensions' | Join-Path -ChildPath 'AzureExtensionsSpec.json'
+        $GeneratedPath = Join-Path -Path $PSScriptRoot -ChildPath 'Generated'
+        $GeneratedModuleBase = Join-Path -Path $GeneratedPath -ChildPath $ModuleName
+        if (Test-Path -Path $GeneratedModuleBase -PathType Container) {
+            Remove-Item -Path $GeneratedModuleBase -Recurse -Force
+        }
+    }
+
+    It 'Test NoVersionFolder switch parameter' {
+        $params = @{
+            SpecificationPath       = $SwaggerSpecPath
+            Name                    = $ModuleName
+            UseAzureCsharpGenerator = $true
+            Path                    = $GeneratedPath
+            NoVersionFolder         = $true
+            ConfirmBootstrap        = $true
+            Verbose                 = $true
+        }
+        Invoke-NewPSSwaggerModuleCommand -NewPSSwaggerModuleParameters $params
+
+        $ModuleInfo = Import-Module $GeneratedModuleBase -Force -PassThru
+        $ModuleInfo.ModuleBase | Should Be $GeneratedModuleBase
+    }
+}

--- a/Tests/TestUtilities.psm1
+++ b/Tests/TestUtilities.psm1
@@ -78,6 +78,9 @@ function Invoke-NewPSSwaggerModuleCommand {
         $NewPSSwaggerModuleParameters['NoAssembly'] = $false
         $NewPSSwaggerModuleParameters['ConfirmBootstrap'] = $true
     }
+    elseif (-not $NewPSSwaggerModuleParameters.ContainsKey('AssemblyFileName'))  {
+        $NewPSSwaggerModuleParameters['NoAssembly'] = $true
+    }
 
     if ((Get-Variable -Name PSEdition -ErrorAction Ignore) -and ('Core' -eq $PSEdition)) {
         if ($IncludeAssembly) {

--- a/docs/commands/New-PSSwaggerModule.md
+++ b/docs/commands/New-PSSwaggerModule.md
@@ -14,30 +14,30 @@ PowerShell command to generate the PowerShell commands for a given RESTful Web S
 ### SpecificationPath (Default)
 ```
 New-PSSwaggerModule -SpecificationPath <String> -Path <String> -Name <String> [-Version <Version>]
- [-DefaultCommandPrefix <String>] [-Header <String[]>] [-UseAzureCsharpGenerator] [-NoAssembly]
- [-PowerShellCorePath <String>] [-IncludeCoreFxAssembly] [-InstallToolsForAllUsers] [-TestBuild]
+ [-NoVersionFolder] [-DefaultCommandPrefix <String>] [-Header <String[]>] [-UseAzureCsharpGenerator]
+ [-NoAssembly] [-PowerShellCorePath <String>] [-IncludeCoreFxAssembly] [-InstallToolsForAllUsers] [-TestBuild]
  [-SymbolPath <String>] [-ConfirmBootstrap]
 ```
 
 ### SdkAssemblyWithSpecificationPath
 ```
 New-PSSwaggerModule -SpecificationPath <String> -Path <String> -AssemblyFileName <String>
- [-ClientTypeName <String>] [-ModelsName <String>] -Name <String> [-Version <Version>]
+ [-ClientTypeName <String>] [-ModelsName <String>] -Name <String> [-Version <Version>] [-NoVersionFolder]
  [-DefaultCommandPrefix <String>] [-Header <String[]>] [-UseAzureCsharpGenerator]
 ```
 
 ### SdkAssemblyWithSpecificationUri
 ```
 New-PSSwaggerModule -SpecificationUri <Uri> -Path <String> -AssemblyFileName <String>
- [-ClientTypeName <String>] [-ModelsName <String>] -Name <String> [-Version <Version>]
+ [-ClientTypeName <String>] [-ModelsName <String>] -Name <String> [-Version <Version>] [-NoVersionFolder]
  [-DefaultCommandPrefix <String>] [-Header <String[]>] [-UseAzureCsharpGenerator]
 ```
 
 ### SpecificationUri
 ```
 New-PSSwaggerModule -SpecificationUri <Uri> -Path <String> -Name <String> [-Version <Version>]
- [-DefaultCommandPrefix <String>] [-Header <String[]>] [-UseAzureCsharpGenerator] [-NoAssembly]
- [-PowerShellCorePath <String>] [-IncludeCoreFxAssembly] [-InstallToolsForAllUsers] [-TestBuild]
+ [-NoVersionFolder] [-DefaultCommandPrefix <String>] [-Header <String[]>] [-UseAzureCsharpGenerator]
+ [-NoAssembly] [-PowerShellCorePath <String>] [-IncludeCoreFxAssembly] [-InstallToolsForAllUsers] [-TestBuild]
  [-SymbolPath <String>] [-ConfirmBootstrap]
 ```
 
@@ -187,6 +187,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: 0.0.1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoVersionFolder
+Switch to not create the version folder under the generated module folder.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
Added -NoVersionFolder switch parameter on New-PSSwaggerModule cmdlet to not create the version folder
Resolves #353