### PR TITLE
Generate single Verb-Noun cmdlet for OperationIds like Noun_Verb and Noun_VerbBySomething

### DIFF
--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -1402,10 +1402,16 @@ function Get-PathCommandName
                 # This is still empty when a verb match is found that is the entire string, but it might not be worth checking for that case and skipping the below operation
                 $cmdNounSuffix = $UnapprovedVerb.Substring($beginningOfSuffix)
                 # Add command noun suffix only when the current noun doesn't contain it or vice-versa. 
-                if(-not $cmdNoun -or (($cmdNoun -notmatch $cmdNounSuffix) -and ($cmdNounSuffix -notmatch $cmdNoun))) {
-                    $cmdNoun = $cmdNoun + (Get-PascalCasedString -Name $UnapprovedVerb.Substring($beginningOfSuffix))
-                } elseif($cmdNounSuffix -match $cmdNoun) {
-                    $cmdNoun = $cmdNounSuffix
+                if(-not $cmdNoun) {
+                    $cmdNoun = Get-PascalCasedString -Name $cmdNounSuffix
+                }                
+                elseif(-not $cmdNounSuffix.StartsWith('By', [System.StringComparison]::OrdinalIgnoreCase)) {
+                    if(($cmdNoun -notmatch $cmdNounSuffix) -and ($cmdNounSuffix -notmatch $cmdNoun)) {
+                        $cmdNoun = $cmdNoun + (Get-PascalCasedString -Name $cmdNounSuffix)
+                    }
+                    elseif($cmdNounSuffix -match $cmdNoun) {
+                        $cmdNoun = $cmdNounSuffix
+                    }
                 }
             }
         }

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -223,7 +223,7 @@ Describe "Optional parameter tests" -Tag ScenarioTest {
         }
 
         It "Generates cmdlet using optional path parameters" {
-            $results = Get-CupcakeByMaker -Flavor "chocolate" -Maker "bob"
+            $results = Get-Cupcake -Flavor "chocolate" -Maker "bob"
             $results.Length | should be 1
         }
 
@@ -528,10 +528,10 @@ Describe "AzureExtensions" -Tag @('AzureExtension','ScenarioTest') {
         }
 
         It "Test x-ms-paths generated cmdlets" {
-            $results = Get-CupcakeById -Id 1
+            $results = Get-Cupcake -Id 1
             $results.Count | should be 1
 
-            $results = Get-CupcakeByFlavor -Flavor 'vanilla'
+            $results = Get-Cupcake -Flavor 'vanilla'
             $results.Count | should be 1
         }
 
@@ -545,6 +545,22 @@ Describe "AzureExtensions" -Tag @('AzureExtension','ScenarioTest') {
             $cmdInfo = Get-Command New-CheckNameAvailabilityInputObject -ErrorVariable ev -ErrorAction SilentlyContinue
             $cmdInfo = Should BeNullOrEmpty
             $ev.FullyQualifiedErrorId | Should Be 'CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand'
+        }
+
+        It "Validate default parameterset name of generated cmdlet" {
+            $CommandInfo = Get-Command -Name Get-Cupcake
+            $DefaultParameterSet = 'Cupcake_List'
+            $ParameterSetNames = @(
+                $DefaultParameterSet,
+                'Cupcake_GetById',
+                'Cupcake_GetByFlavor'
+            )
+            $CommandInfo.DefaultParameterSet | Should Be $DefaultParameterSet
+            $CommandInfo.ParameterSets.Count | Should Be $ParameterSetNames.Count
+
+            $ParameterSetNames | ForEach-Object {
+                $CommandInfo.ParameterSets.Name -contains $_ | Should Be $true                
+            }
         }
     }
 


### PR DESCRIPTION
- Added support for generating the single Verb-Noun cmdlet with multuple parameter sets for OperationIds like Noun_Verb and Noun_VerbBySomething.
- Updated the parameterset prioritazation logic to retrieve the default parameter set with minimum number of mandatory parameters.