### PR TITLE
Can provide credentials for SpecificationUri

### DIFF
--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -302,14 +302,8 @@ function New-PSSwaggerModule {
                 $SwaggerDocumentPath = Join-Path -Path $DocumentFolderPath -ChildPath $FileName
 
                 $ev = $null
-                $webRequestParams = @{
-                    'Uri' = $($BaseSwaggerUri + $($document.replace('\', '/').TrimStart('.')))
-                    'OutFile' = $SwaggerDocumentPath
-                }
-        
-                if($Credential -ne $null) {
-                    $webRequestParams['Credential'] = $Credential
-                }
+                $webRequestParams['Uri'] = $($BaseSwaggerUri + $($document.replace('\', '/').TrimStart('.')))
+                $webRequestParams['OutFile'] = $SwaggerDocumentPath
 
                 Invoke-WebRequest @webRequestParams -ErrorVariable ev
                 if ($ev) {

--- a/docs/commands/New-PSSwaggerModule.md
+++ b/docs/commands/New-PSSwaggerModule.md
@@ -28,14 +28,14 @@ New-PSSwaggerModule -SpecificationPath <String> -Path <String> -AssemblyFileName
 
 ### SdkAssemblyWithSpecificationUri
 ```
-New-PSSwaggerModule -SpecificationUri <Uri> -Path <String> -AssemblyFileName <String>
+New-PSSwaggerModule -SpecificationUri <Uri> [-Credential <PSCredential>] -Path <String> -AssemblyFileName <String>
  [-ClientTypeName <String>] [-ModelsName <String>] -Name <String> [-Version <Version>] [-NoVersionFolder]
  [-DefaultCommandPrefix <String>] [-Header <String[]>] [-UseAzureCsharpGenerator]
 ```
 
 ### SpecificationUri
 ```
-New-PSSwaggerModule -SpecificationUri <Uri> -Path <String> -Name <String> [-Version <Version>]
+New-PSSwaggerModule -SpecificationUri <Uri> [-Credential <PSCredential>] -Path <String> -Name <String> [-Version <Version>]
  [-NoVersionFolder] [-DefaultCommandPrefix <String>] [-Header <String[]>] [-UseAzureCsharpGenerator]
  [-NoAssembly] [-PowerShellCorePath <String>] [-IncludeCoreFxAssembly] [-InstallToolsForAllUsers] [-TestBuild]
  [-SymbolPath <String>] [-ConfirmBootstrap]
@@ -86,6 +86,21 @@ Parameter Sets: SdkAssemblyWithSpecificationUri, SpecificationUri
 Aliases: 
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+Credentials to use when the SpecificationUri requires authentification.
+
+```yaml
+Type: PSCredential
+Parameter Sets: SdkAssemblyWithSpecificationUri, SpecificationUri
+Aliases: 
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
Added a new parameter that allows for a Credential object to be used for WebRequests.  Updated the documentation too.

Apparently the Powershell plugin for VSCode also formatted some stuff too.

