### PR TITLE
Add support for generating ResourceId and InputObject parameter sets for Azure specs

### DIFF
--- a/PSSwagger/Definitions.psm1
+++ b/PSSwagger/Definitions.psm1
@@ -910,6 +910,8 @@ function New-SwaggerSpecDefinitionCommand
     $body = ""
     $DefinitionTypeNamePrefix = "$ModelsNamespace."
     $ParameterSetPropertyString = ""
+    $ValueFromPipelineString = ''
+    $ValueFromPipelineByPropertyNameString = ''
     $parameterDefaultValueOption = ""
 
     $FunctionDetails.ParametersTable.GetEnumerator() | ForEach-Object {
@@ -926,6 +928,7 @@ function New-SwaggerSpecDefinitionCommand
                 $ValidateSetString = $ParameterDetails.ValidateSet
                 $ValidateSetDefinition = $executionContext.InvokeCommand.ExpandString($ValidateSetDefinitionString)
             }
+            $ParameterAliasAttribute = $null
             $paramblock += $executionContext.InvokeCommand.ExpandString($parameterDefString)
 
             $pDescription = $ParameterDetails.Description

--- a/PSSwagger/Get-ArmResourceIdParameterValue.ps1
+++ b/PSSwagger/Get-ArmResourceIdParameterValue.ps1
@@ -22,6 +22,9 @@ function Get-ArmResourceIdParameterValue {
         $IdTemplate
     )
 
+    Write-Verbose -Message ("Resource Id value is '{0}'" -f $Id)
+    Write-Debug -Message ("Resource IdTemplate is '{0}'" -f  $IdTemplate)
+    
     $IdTokens = $Id.Split('/', [System.StringSplitOptions]::RemoveEmptyEntries)
     $IdTemplateTokens = $IdTemplate.Split('/', [System.StringSplitOptions]::RemoveEmptyEntries)
     
@@ -33,9 +36,9 @@ function Get-ArmResourceIdParameterValue {
     $ResourceIdParameterValues = [ordered]@{}
     for ($i = 0; $i -lt $IdTemplateTokens.Count; $i++) {
         if ($IdTokens[$i] -ne $IdTemplateTokens[$i]) {
-            if ($IdTemplateTokens[$i] -notmatch '{*}') {
+            if ($IdTemplateTokens[$i] -notmatch '^{.*}$') {
                 Write-Error -Message ("Invalid resource id '{0}'. Expected id template is '{1}'." -f $Id, $IdTemplate) -ErrorId 'InvalidResourceIdValue'
-                return            
+                return
             }
     
             $ResourceIdParameterValues[$IdTemplateTokens[$i].Trim('{}')] = $IdTokens[$i]

--- a/PSSwagger/Get-ArmResourceIdParameterValue.ps1
+++ b/PSSwagger/Get-ArmResourceIdParameterValue.ps1
@@ -1,0 +1,46 @@
+Microsoft.PowerShell.Core\Set-StrictMode -Version Latest
+
+<#
+.DESCRIPTION
+   Get parameter values from the specified Azure resource identifier.
+
+.PARAMETER  Id
+    The unique resource identifier of the Azure Resource.
+
+.PARAMETER  IdTemplate
+    The unique resource identifier template of the Azure Resource.
+#>
+function Get-ArmResourceIdParameterValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Id,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $IdTemplate
+    )
+
+    $IdTokens = $Id.Split('/', [System.StringSplitOptions]::RemoveEmptyEntries)
+    $IdTemplateTokens = $IdTemplate.Split('/', [System.StringSplitOptions]::RemoveEmptyEntries)
+    
+    if ($IdTokens.Count -ne $IdTemplateTokens.Count) {
+        Write-Error -Message ("Invalid resource id '{0}'. Expected id template is '{1}'." -f $Id, $IdTemplate) -ErrorId 'InvalidResourceIdValue'
+        return
+    }
+    
+    $ResourceIdParameterValues = [ordered]@{}
+    for ($i = 0; $i -lt $IdTemplateTokens.Count; $i++) {
+        if ($IdTokens[$i] -ne $IdTemplateTokens[$i]) {
+            if ($IdTemplateTokens[$i] -notmatch '{*}') {
+                Write-Error -Message ("Invalid resource id '{0}'. Expected id template is '{1}'." -f $Id, $IdTemplate) -ErrorId 'InvalidResourceIdValue'
+                return            
+            }
+    
+            $ResourceIdParameterValues[$IdTemplateTokens[$i].Trim('{}')] = $IdTokens[$i]
+        }
+    }
+
+    return $ResourceIdParameterValues
+}

--- a/PSSwagger/PSSwagger.Constants.ps1
+++ b/PSSwagger/PSSwagger.Constants.ps1
@@ -16,11 +16,11 @@ $helpDescStr = @'
     $description
 '@
 
-$parameterAttributeString = '[Parameter(Mandatory = $isParamMandatory$ParameterSetPropertyString)]'
+$parameterAttributeString = '[Parameter(Mandatory = $isParamMandatory$ValueFromPipelineByPropertyNameString$ValueFromPipelineString$ParameterSetPropertyString)]'
 
 $parameterDefString = @'
     
-        $AllParameterSetsString$ValidateSetDefinition
+        $AllParameterSetsString$ParameterAliasAttribute$ValidateSetDefinition
         $paramType$paramName$parameterDefaultValueOption,
 
 '@
@@ -59,7 +59,9 @@ if (Test-Path -Path `$ClrPath -PathType Container) {
 }
 
 . (Join-Path -Path `$PSScriptRoot -ChildPath 'New-ServiceClient.ps1')
-
+$(if($UseAzureCsharpGenerator) {
+". (Join-Path -Path `$PSScriptRoot -ChildPath 'Get-ArmResourceIdParameterValue.ps1')"
+})
 `$allPs1FilesPath = Join-Path -Path `$PSScriptRoot -ChildPath '$GeneratedCommandsName' | Join-Path -ChildPath '*.ps1'
 Get-ChildItem -Path `$allPs1FilesPath -Recurse -File | ForEach-Object { . `$_.FullName}
 '@
@@ -208,6 +210,8 @@ if($GlobalParameters) {
     $oDataExpressionBlock
     $parameterGroupsExpressionBlock
     $flattenedParametersBlock
+    $ParameterAliasMappingBlock
+    $ResourceIdParamCodeBlock
 
     `$skippedCount = 0
     `$returnedCount = 0
@@ -218,13 +222,13 @@ if($GlobalParameters) {
 '@
 
 $parameterSetBasedMethodStrIfCase = @'
-if ('$operationId' -eq `$PsCmdlet.ParameterSetName) {
+if ($ParameterSetConditionsStr) {
 $additionalConditionStart$methodBlock$additionalConditionEnd
     }
 '@
 
 $parameterSetBasedMethodStrElseIfCase = @'
- elseif ('$operationId' -eq `$PsCmdlet.ParameterSetName ) {
+ elseif ($ParameterSetConditionsStr) {
 $additionalConditionStart$methodBlock$additionalConditionEnd
     }
 '@
@@ -426,6 +430,11 @@ $PagingBlockStrCmdletCall = @'
 $ValidateSetDefinitionString = @'
 
         [ValidateSet($ValidateSetString)]
+'@
+
+$ParameterAliasAttributeString = @'
+
+        [Alias($AliasString)]
 '@
 
 $successReturn = @'

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -49,6 +49,9 @@ Microsoft.PowerShell.Utility\Import-LocalizedData  LocalizedData -filename PSSwa
 .PARAMETER Credential
     Credential to use when the SpecificationUri requires authentication.
 
+.PARAMETER UseDefaultCredential
+    Use default credentials to download the SpecificationUri. Overridden by -Credential when both are specified at the same time.
+
 .PARAMETER  AssemblyFileName
     File name of the pre-compiled SDK assembly.
     This assembly along with its dependencies should be available in '.\ref\fullclr\' folder under the target module version base path ($Path\$Name\$Version\).

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -48,6 +48,7 @@ Microsoft.PowerShell.Utility\Import-LocalizedData  LocalizedData -filename PSSwa
 
 .PARAMETER Credential
     Credential to use when the SpecificationUri requires authentication.
+    It will override -UseDefaultCredential when both are specified at the same time.
 
 .PARAMETER UseDefaultCredential
     Use default credentials to download the SpecificationUri. Overridden by -Credential when both are specified at the same time.

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -47,12 +47,12 @@ Microsoft.PowerShell.Utility\Import-LocalizedData  LocalizedData -filename PSSwa
     Uri to a Swagger based JSON spec.
 
 .PARAMETER Credential
-    Credentials needed when SpecificationUri requires authentification.
+    Credential to use when the SpecificationUri requires authentication.
 
 .PARAMETER  AssemblyFileName
     File name of the pre-compiled SDK assembly.
     This assembly along with its dependencies should be available in '.\ref\fullclr\' folder under the target module version base path ($Path\$Name\$Version\).
-    If your generated module needs to work on PowerShell Core, place the coreclr assembly along with its depdencies under '.\ref\coreclr\' folder under the target module version base path ($Path\$Name\$Version\).
+    If your generated module needs to work on PowerShell Core, place the coreclr assembly along with its dependencies under '.\ref\coreclr\' folder under the target module version base path ($Path\$Name\$Version\).
     For FullClr, the specified assembly should be available at "$Path\$Name\$Version\ref\fullclr\$AssemblyFileName".
     For CoreClr, the specified assembly should be available at "$Path\$Name\$Version\ref\coreclr\$AssemblyFileName".
 
@@ -117,8 +117,15 @@ Microsoft.PowerShell.Utility\Import-LocalizedData  LocalizedData -filename PSSwa
     Automatically consent to downloading nuget.exe or NuGet packages as required.
 
 .PARAMETER  UseAzureCsharpGenerator
-    Switch to specify whether AzureCsharp code generator is required. By default, this command uses CSharp code generator.
+    Switch to specify whether AzureCsharp code generator is required.
+    By default, this command uses CSharp code generator.
 
+    When this switch is specified and the resource id follows the guidelines of Azure Resource operations
+    - The following additional parameter sets will be generated
+      - InputObject parameter set with the same object type returned by Get. Supports piping from Get operarion to action cmdlets.
+      - ResourceId parameter set which splits the resource id into component parts (supports piping from generic cmdlets).
+    - Parameter name of Azure resource name parameter will be generated as 'Name' and the actual resource name parameter from the resource id will be added as an alias.
+    
 .INPUTS
 
 .OUTPUTS
@@ -639,6 +646,7 @@ function New-PSSwaggerModule {
         $CopyFilesMap['New-ArmServiceClient.ps1'] = 'New-ServiceClient.ps1'
         $CopyFilesMap['Test-FullRequirements.ps1'] = 'Test-FullRequirements.ps1'
         $CopyFilesMap['Test-CoreRequirements.ps1'] = 'Test-CoreRequirements.ps1'
+        $CopyFilesMap['Get-ArmResourceIdParameterValue.ps1'] = 'Get-ArmResourceIdParameterValue.ps1'
     }
     else {
         $CopyFilesMap['New-ServiceClient.ps1'] = 'New-ServiceClient.ps1'        

--- a/PSSwagger/PSSwaggerMetadata.psm1
+++ b/PSSwagger/PSSwaggerMetadata.psm1
@@ -377,7 +377,7 @@ function Get-PathsPSMetadata {
             # When multiple operations are combined into single cmdlet,
             # adding first parameterset as the default parameterset name.
             if (-not $defaultParameterSetName) {
-                $defaultParameterSetName = $ParameterSetDetail.OperationId
+                $defaultParameterSetName = $ParameterSetDetail.ParameterSetName
             }
 
             $EndpointRelativePath = $ParameterSetDetail.EndpointRelativePath

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -216,6 +216,14 @@ function Get-SwaggerSpecPathInfo
                 # Priority for parameter sets with mandatory parameters starts at 100
                 $Priority = 100
 
+                # Get Name parameter details, if exists.
+                # If Name parameter is already available, ResourceName parameter name will not be changed.
+                $NameParameterDetails = $ParametersTable.GetEnumerator() | Foreach-Object {
+                    if ($_.Value.Name -eq 'Name') {
+                        $_.Value
+                    }
+                }
+                    
                 $ParametersTable.GetEnumerator() | ForEach-Object {
                     if($_.Value.ContainsKey('Mandatory') -and $_.Value.Mandatory -eq '$true') {
                         $Priority++
@@ -223,6 +231,7 @@ function Get-SwaggerSpecPathInfo
 
                     # Add alias for the resource name parameter.
                     if($ResourceIdAndInputObjectDetails -and
+                       -not $NameParameterDetails -and
                        ($_.Value.Name -ne 'Name') -and
                        ($_.Value.Name -eq $ResourceIdAndInputObjectDetails.ResourceName)) {
                         $_.Value['Alias'] = 'Name'

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -81,6 +81,18 @@ function Get-SwaggerSpecPathInfo
         Get-PathParamInfo @GetPathParamInfo_params
     }
 
+    $ResourceIdAndInputObjectDetails = $null
+    if($UseAzureCsharpGenerator) {
+        $GetResourceIdParameters_params = @{
+            JsonPathItemObject = $JsonPathItemObject
+            ResourceId         = $EndpointRelativePath
+            Namespace          = $SwaggerDict['Info'].NameSpace
+            Models             = $SwaggerDict['Info'].Models
+            DefinitionList     = $swaggerDict['Definitions']
+        }
+        $ResourceIdAndInputObjectDetails = Get-AzureResourceIdParameters @GetResourceIdParameters_params
+    }
+
     $JsonPathItemObject.value.PSObject.Properties | ForEach-Object {
         $longRunningOperation = $false
         $operationType = $_.Name
@@ -208,6 +220,13 @@ function Get-SwaggerSpecPathInfo
                     if($_.Value.ContainsKey('Mandatory') -and $_.Value.Mandatory -eq '$true') {
                         $Priority++
                     }
+
+                    # Add alias for the resource name parameter.
+                    if($ResourceIdAndInputObjectDetails -and
+                       ($_.Value.Name -ne 'Name') -and
+                       ($_.Value.Name -eq $ResourceIdAndInputObjectDetails.ResourceName)) {
+                        $_.Value['Alias'] = 'Name'
+                    }
                 }
 
                 # If there are no mandatory parameters, use the parameter count as the priority.                
@@ -221,6 +240,7 @@ function Get-SwaggerSpecPathInfo
                 Synopsis             = $FunctionSynopsis
                 ParameterDetails     = $ParametersTable
                 Responses            = $responses
+                ParameterSetName     = $operationId
                 OperationId          = $operationId
                 OperationType        = $operationType
                 EndpointRelativePath = $EndpointRelativePath
@@ -246,6 +266,68 @@ function Get-SwaggerSpecPathInfo
                     $ParameterSetDetail['UseOperationsSuffix'] = $true
                 }
             }
+            
+            $InputObjectParameterSetDetail = $null
+            $ResourceIdParameterSetDetail = $null
+            if($ResourceIdAndInputObjectDetails) {
+                # InputObject parameterset
+                $InputObjectParameterDetails = @{
+                    Name                  = 'InputObject'
+                    Type                  = $ResourceIdAndInputObjectDetails.InputObjectParameterType
+                    ValidateSet           = ''
+                    Mandatory             = '$true'
+                    Description           = "The input object of type $($ResourceIdAndInputObjectDetails.InputObjectParameterType)."
+                    IsParameter           = $true
+                    OriginalParameterName = 'InputObject'
+                    FlattenOnPSCmdlet     = $false
+                    ValueFromPipeline     = $true
+                }
+                $InputObjectParamSetParameterDetails = @{ 0 = $InputObjectParameterDetails }
+                $index = 1
+                $ClonedParameterSetDetail = $ParameterSetDetail.Clone()
+                $ClonedParameterSetDetail.ParameterDetails.GetEnumerator() | ForEach-Object {
+                    $paramDetails = $_.Value
+                    if($ResourceIdAndInputObjectDetails.ResourceIdParameters -notcontains $paramDetails.Name) {
+                        $InputObjectParamSetParameterDetails[$index++] = $paramDetails
+                    }
+                }
+                $ClonedParameterSetDetail.ParameterDetails = $InputObjectParamSetParameterDetails
+                $ClonedParameterSetDetail.Priority += 1
+                $ClonedParameterSetDetail.ParameterSetName = "InputObject_$($ClonedParameterSetDetail.ParameterSetName)"
+                $InputObjectParameterSetDetail = $ClonedParameterSetDetail
+
+                # ResourceId parameterset
+                $ResourceIdParameterDetails = @{
+                    Name                            = 'ResourceId'
+                    Type                            = 'System.String'
+                    ValidateSet                     = ''
+                    Mandatory                       = '$true'
+                    Description                     = 'The resource id.'
+                    IsParameter                     = $true
+                    OriginalParameterName           = 'ResourceId'
+                    FlattenOnPSCmdlet               = $false
+                    ValueFromPipelineByPropertyName = $true
+                }
+                $ResourceIdParamSetParameterDetails = @{ 0 = $ResourceIdParameterDetails }
+                $index = 1
+                $ClonedParameterSetDetail = $ParameterSetDetail.Clone()
+                $ClonedParameterSetDetail.ParameterDetails.GetEnumerator() | ForEach-Object {
+                    $paramDetails = $_.Value
+                    if($ResourceIdAndInputObjectDetails.ResourceIdParameters -notcontains $paramDetails.Name) {
+                        $ResourceIdParamSetParameterDetails[$index++] = $paramDetails
+                    }
+                }
+                $ClonedParameterSetDetail.ParameterDetails = $ResourceIdParamSetParameterDetails
+                $ClonedParameterSetDetail.Priority += 2
+                $ClonedParameterSetDetail.ParameterSetName = "ResourceId_$($ClonedParameterSetDetail.ParameterSetName)"
+                $ResourceIdParameterSetDetail = $ClonedParameterSetDetail
+
+                $ParameterSetDetail['ClonedParameterSetNames'] = @(
+                    "InputObject_$($ParameterSetDetail.ParameterSetName)",
+                    "ResourceId_$($ParameterSetDetail.ParameterSetName)"
+                )
+                $ParameterSetDetail['ResourceIdParameters'] = $ResourceIdAndInputObjectDetails.ResourceIdParameters
+            }
 
             $commandNames | ForEach-Object {
                 $FunctionDetails = @{}
@@ -266,6 +348,13 @@ function Get-SwaggerSpecPathInfo
                 } 
 
                 $ParameterSetDetails += $ParameterSetDetail
+                if($InputObjectParameterSetDetail) {
+                    $ParameterSetDetails += $InputObjectParameterSetDetail
+                }
+                if($ResourceIdParameterSetDetail) {
+                    $ParameterSetDetails += $ResourceIdParameterSetDetail
+                }
+    
                 $FunctionDetails['ParameterSetDetails'] = $ParameterSetDetails
                 $PathFunctionDetails[$_.name] = $FunctionDetails
             }
@@ -359,7 +448,7 @@ function Add-UniqueParameter {
 
         [Parameter(Mandatory=$true)]
         [string]
-        $OperationId,
+        $ParameterSetName,
 
         [Parameter(Mandatory=$true)]
         [hashtable]
@@ -383,14 +472,14 @@ function Add-UniqueParameter {
             $parametersToAdd[$parameterName] = @{
                 # We can grab details like Type, Name, ValidateSet from any of the parameter definitions
                 Details = $CandidateParameterDetails
-                ParameterSetInfo = @{$OperationId = @{
-                    Name = $OperationId
+                ParameterSetInfo = @{$ParameterSetName = @{
+                    Name = $ParameterSetName
                     Mandatory = $CandidateParameterDetails.Mandatory
                 }}
             }
         } else {
-            $parametersToAdd[$parameterName].ParameterSetInfo[$OperationId] = @{
-                                                                        Name = $OperationId
+            $parametersToAdd[$parameterName].ParameterSetInfo[$ParameterSetName] = @{
+                                                                        Name = $ParameterSetName
                                                                         Mandatory = $CandidateParameterDetails.Mandatory
                                                                     }
         }
@@ -537,7 +626,7 @@ function New-SwaggerPath
             if ($parameterRequiresAdding) {
                 $AddUniqueParameter_params = @{
                     ParameterDetails = $parameterDetails
-                    OperationId = $parameterSetDetail.OperationId
+                    ParameterSetName = $parameterSetDetail.ParameterSetName
                     ParametersToAdd = $parametersToAdd
                     ParameterHitCount = $parameterHitCount
                 }
@@ -761,15 +850,15 @@ function New-SwaggerPath
     foreach ($parameterSetDetail in $parameterSetDetails) {
         # Add parameter sets to paging parameter sets
         if ($topParameterToAdd -and $parameterSetDetail.ContainsKey('x-ms-pageable') -and $parameterSetDetail.'x-ms-pageable' -and (-not $isNextPageOperation)) {
-            $topParameterToAdd.ParameterSetInfo[$parameterSetDetail.OperationId] = @{
-                Name = $parameterSetDetail.OperationId
+            $topParameterToAdd.ParameterSetInfo[$parameterSetDetail.ParameterSetName] = @{
+                Name = $parameterSetDetail.ParameterSetName
                 Mandatory = '$false'
             }
         }
 
         if ($skipParameterToAdd -and $parameterSetDetail.ContainsKey('x-ms-pageable') -and $parameterSetDetail.'x-ms-pageable' -and (-not $isNextPageOperation)) {
-            $skipParameterToAdd.ParameterSetInfo[$parameterSetDetail.OperationId] = @{
-                Name = $parameterSetDetail.OperationId
+            $skipParameterToAdd.ParameterSetInfo[$parameterSetDetail.ParameterSetName] = @{
+                Name = $parameterSetDetail.ParameterSetName
                 Mandatory = '$false'
             }
         }
@@ -798,7 +887,7 @@ function New-SwaggerPath
             foreach ($additionalParameter in $securityParametersToAdd) {
                 if ($parameterDetails.Name -eq $additionalParameter.Parameter.Details.Name) {
                     $additionalParameter.IsConflictingWithOperationParameter = $true
-                    Write-Warning -Message ($LocalizedData.ParameterConflictAndResult -f ($additionalParameter.Parameter.Details.Name, $commandName, $parameterSetDetail.OperationId, $LocalizedData.CredentialParameterNotSupported))
+                    Write-Warning -Message ($LocalizedData.ParameterConflictAndResult -f ($additionalParameter.Parameter.Details.Name, $commandName, $parameterSetDetail.ParameterSetName, $LocalizedData.CredentialParameterNotSupported))
                 }
             }
             
@@ -855,19 +944,19 @@ function New-SwaggerPath
         # Pick the highest priority set among $nonUniqueParameterSets, but really it doesn't matter, cause...
         # Print warning that this generated cmdlet has ambiguous parameter sets
         $defaultParameterSet = $nonUniqueParameterSets | Sort-Object {$_.Priority} | Select-Object -First 1
-        $DefaultParameterSetName = $defaultParameterSet.OperationId
+        $DefaultParameterSetName = $defaultParameterSet.ParameterSetName
         $description = $defaultParameterSet.Description
         $synopsis = $defaultParameterSet.Synopsis
         Write-Warning -Message ($LocalizedData.CmdletHasAmbiguousParameterSets -f ($commandName))
     } elseif ($nonUniqueParameterSets.Length -eq 1) {
         # If there's only one non-unique, we can prevent errors by making this the default
-        $DefaultParameterSetName = $nonUniqueParameterSets[0].OperationId
+        $DefaultParameterSetName = $nonUniqueParameterSets[0].ParameterSetName
         $description = $nonUniqueParameterSets[0].Description
         $synopsis = $nonUniqueParameterSets[0].Synopsis
     } else {
         # Pick the highest priority set among all sets
         $defaultParameterSet = $parameterSetDetails | Sort-Object @{e = {$_.Priority -as [int] }} | Select-Object -First 1
-        $DefaultParameterSetName = $defaultParameterSet.OperationId
+        $DefaultParameterSetName = $defaultParameterSet.ParameterSetName
         $description = $defaultParameterSet.Description
         $synopsis = $defaultParameterSet.Synopsis        
     }
@@ -878,10 +967,22 @@ function New-SwaggerPath
     $parameterGroupsExpressionBlock = ""
     # Variable used to store all group expressions, concatenate, then store in $parameterGroupsExpressionBlock
     $parameterGroupsExpressions = @{}
+    $ParameterAliasMapping = @{}
     $parametersToAdd.GetEnumerator() | ForEach-Object {
         $parameterToAdd = $_.Value
+        $ValueFromPipelineString = ''
+        $ValueFromPipelineByPropertyNameString = ''
         if ($parameterToAdd) {
             $parameterName = $parameterToAdd.Details.Name
+            
+            if($parameterToAdd.Details.Containskey('ValueFromPipeline') -and $parameterToAdd.Details.ValueFromPipeline) {
+                $ValueFromPipelineString = ', ValueFromPipeline = $true'
+            }
+
+            if($parameterToAdd.Details.Containskey('ValueFromPipelineByPropertyName') -and $parameterToAdd.Details.ValueFromPipelineByPropertyName) {
+                $ValueFromPipelineByPropertyNameString = ', ValueFromPipelineByPropertyName = $true'
+            }
+
             $AllParameterSetsString = ''
             foreach ($parameterSetInfoEntry in $parameterToAdd.ParameterSetInfo.GetEnumerator()) {
                 $parameterSetInfo = $parameterSetInfoEntry.Value
@@ -901,7 +1002,19 @@ function New-SwaggerPath
                 $AllParameterSetsString = $executionContext.InvokeCommand.ExpandString($parameterAttributeString)
             }
 
-            $paramName = "`$$parameterName" 
+            $ParameterAliasAttribute = $null
+            # Parameter has Name as an alias, change the parameter name to Name and add the current parameter name as an alias.            
+            if ($parameterToAdd.Details.Containskey('Alias') -and 
+                $parameterToAdd.Details.Alias -and
+                ($parameterToAdd.Details.Alias -eq 'Name'))
+            {
+                $ParameterAliasMapping[$parameterName] = 'Name'
+                $AliasString = "'$parameterName'"
+                $parameterName = 'Name'
+                $ParameterAliasAttribute = $executionContext.InvokeCommand.ExpandString($ParameterAliasAttributeString)
+            }
+
+            $paramName = "`$$parameterName"
             $ValidateSetDefinition = $null
             if ($parameterToAdd.Details.ValidateSet)
             {
@@ -997,6 +1110,7 @@ function New-SwaggerPath
         SwaggerDict                       = $SwaggerDict
         SwaggerMetaDict                   = $SwaggerMetaDict
         FlattenedParametersOnPSCmdlet     = $flattenedParametersOnPSCmdlet
+        ParameterAliasMapping             = $ParameterAliasMapping
     }
     if($AuthenticationCommand) {
         $functionBodyParams['AuthenticationCommand'] = $AuthenticationCommand

--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -1815,12 +1815,10 @@ function Get-AzureResourceIdParameters {
         Write-Debug -Message ("The specified endpoint '{0}' is not a valid resource identifier." -f $ResourceId)
         return
     }
-    $ResourceIdParameters = $tokens | Where-Object {$_ -match '{*}'} | Foreach-Object {
-        if ($_ -match '{*}') {
-            $parameterName = $_.Trim('{}')
-            if ($parameterName -ne 'SubscriptionId') {
-                $parameterName
-            }
+    $ResourceIdParameters = $tokens | Where-Object {$_ -match '^{.*}$'} | Foreach-Object {
+        $parameterName = $_.Trim('{}')
+        if ($parameterName -ne 'SubscriptionId') {
+            $parameterName
         }
     }
     if(-not $ResourceIdParameters -or ("{$($ResourceIdParameters[-1])}" -ne $tokens[-1])) {

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -12,15 +12,15 @@ Import-Module (Join-Path "$PSScriptRoot" "TestUtilities.psm1")
 Describe "Basic API" -Tag ScenarioTest {
     BeforeAll {
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger" | Join-Path -ChildPath "PSSwaggerUtility" | `
-                       Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
+                Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
         Initialize-Test -GeneratedModuleName "Generated.Basic.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "PsSwaggerTestBasic" `
-                        -TestSpecFileName "PsSwaggerTestBasicSpec.json" -TestDataFileName "PsSwaggerTestBasicData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+            -TestSpecFileName "PsSwaggerTestBasicSpec.json" -TestDataFileName "PsSwaggerTestBasicData.json" `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
 
         # Import generated module
         Write-Verbose "Importing modules"
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath "Generated.Basic.Module")
+                Join-Path -ChildPath "Generated.Basic.Module")
         $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "PsSwaggerTestBasic" -TestRoutesFileName "PsSwaggerTestBasicRoutes.json" -Verbose
         if ($global:PSSwaggerTest_EnableTracing -and $script:EnableTracer) {
             $script:EnableTracer = $false
@@ -45,8 +45,7 @@ Describe "Basic API" -Tag ScenarioTest {
             $ModuleInfo.Author | Should be 'support@swagger.io'
             $ModuleInfo.CopyRight | Should be 'Apache 2.0'
 
-            if($PSVersionTable.PSVersion -ge '5.0.0')
-            {
+            if ($PSVersionTable.PSVersion -ge '5.0.0') {
                 $ModuleInfo.PrivateData.PSData.LicenseUri | Should be 'http://www.apache.org/licenses/LICENSE-2.0.html'
                 $ModuleInfo.PrivateData.PSData.ProjectUri | Should be 'http://www.swagger.io/support'
             }
@@ -61,15 +60,15 @@ Describe "Basic API" -Tag ScenarioTest {
 Describe "All Operations: Basic" -Tag ScenarioTest {
     BeforeAll {
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger" | Join-Path -ChildPath "PSSwaggerUtility" | `
-                       Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
+                Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
         Initialize-Test -GeneratedModuleName "Generated.TypesTest.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "OperationTypes" `
-                        -TestSpecFileName "OperationTypesSpec.json" -TestDataFileName "OperationTypesData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+            -TestSpecFileName "OperationTypesSpec.json" -TestDataFileName "OperationTypesData.json" `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
 
         # Import generated module
         Write-Verbose "Importing modules"
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath "Generated.TypesTest.Module")
+                Join-Path -ChildPath "Generated.TypesTest.Module")
         
         $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "OperationTypes" -TestMiddlewareFileNames "OperationTypesMiddleware.js" -TestRoutesFileName "OperationTypesRoutes.json"
         if ($global:PSSwaggerTest_EnableTracing -and $script:EnableTracer) {
@@ -125,7 +124,7 @@ Describe "All Operations: Basic" -Tag ScenarioTest {
         }
 
         It "Verify Path level common parameters" {
-            @('Get-CupCake2','New-CupCake2','Remove-CupCake2', 'Set-CupCake2') | ForEach-Object {
+            @('Get-CupCake2', 'New-CupCake2', 'Remove-CupCake2', 'Set-CupCake2') | ForEach-Object {
                 $Command = Get-Command $_
                 $Command.Parameters.ContainsKey('Id') | Should be $true
             }
@@ -140,15 +139,15 @@ Describe "All Operations: Basic" -Tag ScenarioTest {
 Describe "Get/List tests" -Tag ScenarioTest {
     BeforeAll {
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger" | Join-Path -ChildPath "PSSwaggerUtility" | `
-                       Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
+                Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
         Initialize-Test -GeneratedModuleName "Generated.GetList.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "GetListTests" `
-                        -TestSpecFileName "GetListTestsSpec.json" -TestDataFileName "GetListTestsData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+            -TestSpecFileName "GetListTestsSpec.json" -TestDataFileName "GetListTestsData.json" `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
 
         # Import generated module
         Write-Verbose "Importing modules"
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath "Generated.GetList.Module")
+                Join-Path -ChildPath "Generated.GetList.Module")
 
         $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "GetListTests" -TestRoutesFileName "GetListTestsRoutes.json"
         if ($global:PSSwaggerTest_EnableTracing -and $script:EnableTracer) {
@@ -185,15 +184,15 @@ Describe "Get/List tests" -Tag ScenarioTest {
 Describe "Optional parameter tests" -Tag ScenarioTest {
     BeforeAll {
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger" | Join-Path -ChildPath "PSSwaggerUtility" | `
-                       Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
+                Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
         Initialize-Test -GeneratedModuleName "Generated.Optional.Module" -GeneratedModuleVersion "0.0.2" -TestApiName "OptionalParametersTests" `
-                        -TestSpecFileName "OptionalParametersTestsSpec.json" -TestDataFileName "OptionalParametersTestsData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+            -TestSpecFileName "OptionalParametersTestsSpec.json" -TestDataFileName "OptionalParametersTestsData.json" `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
 
         # Import generated module
         Write-Verbose "Importing modules"
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath "Generated.Optional.Module")
+                Join-Path -ChildPath "Generated.Optional.Module")
         $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "OptionalParametersTests" -TestRoutesFileName "OptionalParametersTestsRoutes.json"
         if ($global:PSSwaggerTest_EnableTracing -and $script:EnableTracer) {
             $script:EnableTracer = $false
@@ -243,19 +242,19 @@ Describe "Optional parameter tests" -Tag ScenarioTest {
     }
 }
 
-Describe "ParameterTypes tests" -Tag @('ParameterTypes','ScenarioTest') {
+Describe "ParameterTypes tests" -Tag @('ParameterTypes', 'ScenarioTest') {
     BeforeAll {
         $ModuleName = 'Generated.ParamTypes.Module'        
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger" | Join-Path -ChildPath "PSSwaggerUtility" | `
-                       Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
+                Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
         Initialize-Test -GeneratedModuleName $ModuleName -GeneratedModuleVersion "0.0.2" -TestApiName "ParameterTypes" `
-                        -TestSpecFileName "ParameterTypesSpec.json" -TestDataFileName "ParameterTypesData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+            -TestSpecFileName "ParameterTypesSpec.json" -TestDataFileName "ParameterTypesData.json" `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
 
         # Import generated module
         Write-Verbose "Importing modules"
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath $ModuleName)
+                Join-Path -ChildPath $ModuleName)
 
         $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "ParameterTypes"
         if ($global:PSSwaggerTest_EnableTracing -and $script:EnableTracer) {
@@ -379,8 +378,8 @@ Describe "ParameterTypes tests" -Tag @('ParameterTypes','ScenarioTest') {
             $ev | Should BeNullOrEmpty
             
             $CommandNames = @('New-FieldDefinitionObject',
-                              'New-NamespaceNestedTypeObject',
-                              'New-KeyCredentialObject')
+                'New-NamespaceNestedTypeObject',
+                'New-KeyCredentialObject')
             $CommandNames | ForEach-Object {
                 $CommandList.Name -CContains $_ | Should be $True
             }
@@ -414,7 +413,7 @@ Describe "ParameterTypes tests" -Tag @('ParameterTypes','ScenarioTest') {
             $OperationCommandInfo = Get-Command -Name Get-PathWithEnumDefinitionType -Module $ModuleName
 
             $OperationCommandInfo.Parameters.PolicyNameEnumParameter.ParameterType.ToString() | Should BeExactly 'System.String'
-            @('AppGwSslPolicy20150501', 'AppGwSslPolicy20170401','AppGwSslPolicy20170401S') | ForEach-Object {
+            @('AppGwSslPolicy20150501', 'AppGwSslPolicy20170401', 'AppGwSslPolicy20170401S') | ForEach-Object {
                 $OperationCommandInfo.Parameters.PolicyNameEnumParameter.Attributes.ValidValues -contains $_ | Should Be $true
             }
 
@@ -422,22 +421,22 @@ Describe "ParameterTypes tests" -Tag @('ParameterTypes','ScenarioTest') {
             $NewObjectCommandInfo = Get-Command -Name New-ApplicationGatewaySslPolicyObject -Module $ModuleName
 
             $NewObjectCommandInfo.Parameters.PolicyType.ParameterType.ToString() | Should BeExactly 'System.String'
-            @('Predefined','Custom') | ForEach-Object {
+            @('Predefined', 'Custom') | ForEach-Object {
                 $NewObjectCommandInfo.Parameters.PolicyType.Attributes.ValidValues -contains $_ | Should Be $true
             }
 
             $NewObjectCommandInfo.Parameters.DisabledSslProtocols.ParameterType.ToString() | Should BeExactly 'System.String[]'
-            @('TLSv1_0','TLSv1_1', 'TLSv1_2') | ForEach-Object {
+            @('TLSv1_0', 'TLSv1_1', 'TLSv1_2') | ForEach-Object {
                 $NewObjectCommandInfo.Parameters.DisabledSslProtocols.Attributes.ValidValues -contains $_ | Should Be $true
             }
 
             $NewObjectCommandInfo.Parameters.PolicyName.ParameterType.ToString() | Should BeExactly 'System.String'
-            @('AppGwSslPolicy20150501', 'AppGwSslPolicy20170401','AppGwSslPolicy20170401S') | ForEach-Object {
+            @('AppGwSslPolicy20150501', 'AppGwSslPolicy20170401', 'AppGwSslPolicy20170401S') | ForEach-Object {
                 $NewObjectCommandInfo.Parameters.PolicyName.Attributes.ValidValues -contains $_ | Should Be $true
             }
 
             $NewObjectCommandInfo.Parameters.MinProtocolVersion.ParameterType.ToString() | Should BeExactly 'System.String'
-            @('TLSv1_0','TLSv1_1', 'TLSv1_2') | ForEach-Object {
+            @('TLSv1_0', 'TLSv1_1', 'TLSv1_2') | ForEach-Object {
                 $NewObjectCommandInfo.Parameters.MinProtocolVersion.Attributes.ValidValues -contains $_ | Should Be $true
             }
         }
@@ -448,18 +447,18 @@ Describe "ParameterTypes tests" -Tag @('ParameterTypes','ScenarioTest') {
     }
 }
 
-Describe "AzureExtensions" -Tag @('AzureExtension','ScenarioTest') {
+Describe "AzureExtensions" -Tag @('AzureExtension', 'ScenarioTest') {
     BeforeAll {
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger" | Join-Path -ChildPath "PSSwaggerUtility" | `
-                       Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
+                Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
         Initialize-Test -GeneratedModuleName "Generated.AzExt.Module" -GeneratedModuleVersion "1.3.3.7" -TestApiName "AzureExtensions" `
-                        -TestSpecFileName "AzureExtensionsSpec.json" -TestDataFileName "AzureExtensionsData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+            -TestSpecFileName "AzureExtensionsSpec.json" -TestDataFileName "AzureExtensionsData.json" `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
 
         # Import generated module
         Write-Verbose "Importing modules"
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath "Generated.AzExt.Module")
+                Join-Path -ChildPath "Generated.AzExt.Module")
         
         $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "AzureExtensions" -TestRoutesFileName "AzureExtensionsRoutes.json"
         if ($global:PSSwaggerTest_EnableTracing -and $script:EnableTracer) {
@@ -569,7 +568,7 @@ Describe "AzureExtensions" -Tag @('AzureExtension','ScenarioTest') {
     }
 }
 
-Describe "Composite Swagger Tests" -Tag @('Composite','ScenarioTest') {
+Describe "Composite Swagger Tests" -Tag @('Composite', 'ScenarioTest') {
     Context "Module generation for composite swagger specs" {
         It "New-PSSwaggerModule with composite swagger spec" {            
             $ModuleName = 'CompositeSwaggerModule'
@@ -581,12 +580,13 @@ Describe "Composite Swagger Tests" -Tag @('Composite','ScenarioTest') {
             }
 
             Import-Module $PsSwaggerPath -Force
-            if((Get-Variable -Name PSEdition -ErrorAction Ignore) -and ('Core' -eq $PSEdition)) {
+            if ((Get-Variable -Name PSEdition -ErrorAction Ignore) -and ('Core' -eq $PSEdition)) {
                 & "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe" -command "& {`$env:PSModulePath=`$env:PSModulePath_Backup;
                     Import-Module (Join-Path `"$PsSwaggerPath`" `"PSSwagger.psd1`") -Force -ArgumentList `$true;
                     New-PSSwaggerModule -SpecificationPath $SwaggerSpecPath -Name $ModuleName -UseAzureCsharpGenerator -Path $Path -NoAssembly -Verbose -ConfirmBootstrap;
                 }"
-            } else {
+            }
+            else {
                 New-PSSwaggerModule -SpecificationPath $SwaggerSpecPath -Name $ModuleName -UseAzureCsharpGenerator -Path $Path -NoAssembly -Verbose -ConfirmBootstrap
             }
         
@@ -626,18 +626,18 @@ Describe "Composite Swagger Tests" -Tag @('Composite','ScenarioTest') {
     }
 }
 
-Describe "AllOfDefinition" -Tag @('AllOf','ScenarioTest')  {
+Describe "AllOfDefinition" -Tag @('AllOf', 'ScenarioTest') {
     BeforeAll {
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger" | Join-Path -ChildPath "PSSwaggerUtility" | `
-                       Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
+                Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
         Initialize-Test -GeneratedModuleName "Generated.AllOfDefinition.Module" -TestApiName "AllOfDefinition" `
-                        -TestSpecFileName "AllOfDefinitionSpec.json"  `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+            -TestSpecFileName "AllOfDefinitionSpec.json"  `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
 
         # Import generated module
         Write-Verbose "Importing modules"
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath "Generated.AllOfDefinition.Module")
+                Join-Path -ChildPath "Generated.AllOfDefinition.Module")
     }
 
     Context "AllOfDefinition" {
@@ -652,34 +652,34 @@ Describe "AllOfDefinition" -Tag @('AllOf','ScenarioTest')  {
     }
 }
 
-Describe "AuthTests" -Tag @('Auth','ScenarioTest') {
+Describe "AuthTests" -Tag @('Auth', 'ScenarioTest') {
     BeforeAll {
         # Generate all auth modules
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger" | Join-Path -ChildPath "PSSwaggerUtility" | `
-                       Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
+                Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
         Initialize-Test -GeneratedModuleName "Generated.BasicAuthTest.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "AuthTests" `
-                        -TestSpecFileName "BasicAuthSpec.json" -TestDataFileName "AuthTestData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
-         Initialize-Test -GeneratedModuleName "Generated.BasicAuthTestNoChallenge.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "AuthTests" `
-                        -TestSpecFileName "BasicAuthSpecNoChallenge.json" -TestDataFileName "AuthTestData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+            -TestSpecFileName "BasicAuthSpec.json" -TestDataFileName "AuthTestData.json" `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+        Initialize-Test -GeneratedModuleName "Generated.BasicAuthTestNoChallenge.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "AuthTests" `
+            -TestSpecFileName "BasicAuthSpecNoChallenge.json" -TestDataFileName "AuthTestData.json" `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
         Initialize-Test -GeneratedModuleName "Generated.ApiKeyHeaderTest.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "AuthTests" `
-                        -TestSpecFileName "ApiKeyHeaderSpec.json" -TestDataFileName "AuthTestData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+            -TestSpecFileName "ApiKeyHeaderSpec.json" -TestDataFileName "AuthTestData.json" `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
         Initialize-Test -GeneratedModuleName "Generated.ApiKeyQueryTest.Module" -GeneratedModuleVersion "0.0.1" -TestApiName "AuthTests" `
-                        -TestSpecFileName "ApiKeyQuerySpec.json" -TestDataFileName "AuthTestData.json" `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+            -TestSpecFileName "ApiKeyQuerySpec.json" -TestDataFileName "AuthTestData.json" `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
         
         # Import generated modules
         Write-Verbose "Importing modules"
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath "Generated.BasicAuthTest.Module")
+                Join-Path -ChildPath "Generated.BasicAuthTest.Module")
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath "Generated.BasicAuthTestNoChallenge.Module")
+                Join-Path -ChildPath "Generated.BasicAuthTestNoChallenge.Module")
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath "Generated.ApiKeyHeaderTest.Module") -Prefix "ApiKeyHeader"
+                Join-Path -ChildPath "Generated.ApiKeyHeaderTest.Module") -Prefix "ApiKeyHeader"
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath "Generated.ApiKeyQueryTest.Module") -Prefix "ApiKeyQuery"
+                Join-Path -ChildPath "Generated.ApiKeyQueryTest.Module") -Prefix "ApiKeyQuery"
 
         if ($global:PSSwaggerTest_EnableTracing -and $script:EnableTracer) {
             $script:EnableTracer = $false
@@ -697,12 +697,12 @@ Describe "AuthTests" -Tag @('Auth','ScenarioTest') {
             # Generate credential
             $username = "username"
             $password = ConvertTo-SecureString "password" -AsPlainText -Force
-            $creds = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $username,$password
+            $creds = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $username, $password
 
             # Run test
             try {
                 $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "AuthTests" -TestMiddlewareFileNames 'AuthTestMiddleware.js' `
-                                              -CustomServerParameters "--auth .\BasicAuth.js" # Contains function to verify a hardcoded basic auth header
+                    -CustomServerParameters "--auth .\BasicAuth.js" # Contains function to verify a hardcoded basic auth header
                 Get-Response -Credential $creds -Property "test"
             }
             finally {
@@ -714,12 +714,12 @@ Describe "AuthTests" -Tag @('Auth','ScenarioTest') {
             # Generate credential
             $username = "username"
             $password = ConvertTo-SecureString "passwordAlt" -AsPlainText -Force
-            $creds = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $username,$password
+            $creds = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $username, $password
 
             # Run test
             try {
                 $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "AuthTests" -TestMiddlewareFileNames 'AuthTestMiddlewareNoChallenge.js' `
-                                              -CustomServerParameters "--auth .\BasicAuthAltCreds.js" # Contains function to verify a hardcoded basic auth header
+                    -CustomServerParameters "--auth .\BasicAuthAltCreds.js" # Contains function to verify a hardcoded basic auth header
                 Get-ResponseUnchallenged -Credential $creds -Property "test"
             }
             finally {
@@ -731,12 +731,12 @@ Describe "AuthTests" -Tag @('Auth','ScenarioTest') {
             # Generate credential
             $username = "username1"
             $password = ConvertTo-SecureString "password" -AsPlainText -Force
-            $creds = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $username,$password
+            $creds = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $username, $password
 
             # Run test
             try {
                 $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "AuthTests" -TestMiddlewareFileNames 'AuthTestMiddleware.js' `
-                                              -CustomServerParameters "--auth .\BasicAuth.js" # Contains function to verify a hardcoded basic auth header
+                    -CustomServerParameters "--auth .\BasicAuth.js" # Contains function to verify a hardcoded basic auth header
                 { Get-Response -Credential $creds -Property "test" } | should throw 'Unauthorized'
             }
             finally {
@@ -748,12 +748,12 @@ Describe "AuthTests" -Tag @('Auth','ScenarioTest') {
             # Generate credential
             $username = "username"
             $password = ConvertTo-SecureString "password1" -AsPlainText -Force
-            $creds = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $username,$password
+            $creds = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $username, $password
 
             # Run test
             try {
                 $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "AuthTests" -TestMiddlewareFileNames 'AuthTestMiddleware.js' `
-                                              -CustomServerParameters "--auth .\BasicAuth.js" # Contains function to verify a hardcoded basic auth header
+                    -CustomServerParameters "--auth .\BasicAuth.js" # Contains function to verify a hardcoded basic auth header
                 { Get-Response -Credential $creds -Property "test" } | should throw 'Unauthorized'
             }
             finally {
@@ -764,7 +764,7 @@ Describe "AuthTests" -Tag @('Auth','ScenarioTest') {
         It "Allows overriding security requirement at operation level" {
             try {
                 $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "AuthTests" -TestMiddlewareFileNames 'AuthTestMiddleware.js' `
-                                              -CustomServerParameters "--auth .\ApiKeyWithQuery.js" # Contains function to verify a hardcoded API key in the query
+                    -CustomServerParameters "--auth .\ApiKeyWithQuery.js" # Contains function to verify a hardcoded API key in the query
                 Get-ResponseWithApiKey -APIKey "abc123" -Property "test"
             }
             finally {
@@ -787,7 +787,7 @@ Describe "AuthTests" -Tag @('Auth','ScenarioTest') {
         It "Succeeds with key" {
             try {
                 $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "AuthTests" -TestMiddlewareFileNames 'AuthTestMiddleware.js' `
-                                              -CustomServerParameters "--auth .\ApiKeyWithHeader.js" # Contains function to verify a hardcoded API key in the header
+                    -CustomServerParameters "--auth .\ApiKeyWithHeader.js" # Contains function to verify a hardcoded API key in the header
                 Get-ApiKeyHeaderResponse -APIKey "abc123" -Property "test"
             }
             finally {
@@ -798,7 +798,7 @@ Describe "AuthTests" -Tag @('Auth','ScenarioTest') {
         It "Fails with incorrect key" {
             try {
                 $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "AuthTests" -TestMiddlewareFileNames 'AuthTestMiddleware.js' `
-                                              -CustomServerParameters "--auth .\ApiKeyWithHeader.js" # Contains function to verify a hardcoded API key in the header
+                    -CustomServerParameters "--auth .\ApiKeyWithHeader.js" # Contains function to verify a hardcoded API key in the header
                 { Get-ApiKeyHeaderResponse -APIKey "abc12345" -Property "test" } | should throw 'Unauthorized'
             }
             finally {
@@ -811,7 +811,7 @@ Describe "AuthTests" -Tag @('Auth','ScenarioTest') {
         It "Succeeds with key" {
             try {
                 $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "AuthTests" -TestMiddlewareFileNames 'AuthTestMiddleware.js' `
-                                              -CustomServerParameters "--auth .\ApiKeyWithQuery.js" # Contains function to verify a hardcoded API key in the query
+                    -CustomServerParameters "--auth .\ApiKeyWithQuery.js" # Contains function to verify a hardcoded API key in the query
                 Get-ApiKeyQueryResponse -APIKey "abc123" -Property "test"
             }
             finally {
@@ -822,7 +822,7 @@ Describe "AuthTests" -Tag @('Auth','ScenarioTest') {
         It "Fails with incorrect key" {
             try {
                 $processes = Start-JsonServer -TestRootPath $PSScriptRoot -TestApiName "AuthTests" -TestMiddlewareFileNames 'AuthTestMiddleware.js' `
-                                              -CustomServerParameters "--auth .\ApiKeyWithQuery.js" # Contains function to verify a hardcoded API key in the query
+                    -CustomServerParameters "--auth .\ApiKeyWithQuery.js" # Contains function to verify a hardcoded API key in the query
                 { Get-ApiKeyQueryResponse -APIKey "abc12345" -Property "test" } | should throw 'Unauthorized'
             }
             finally {
@@ -832,18 +832,18 @@ Describe "AuthTests" -Tag @('Auth','ScenarioTest') {
     }
 }
 
-Describe "PSMetadataTests" -Tag @('PSMetadata','ScenarioTest')  {
+Describe "PSMetadataTests" -Tag @('PSMetadata', 'ScenarioTest') {
     BeforeAll {
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger" | Join-Path -ChildPath "PSSwaggerUtility" | `
-                       Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
+                Join-Path -ChildPath "PSSwaggerUtility.psd1") -Force
         Initialize-Test -GeneratedModuleName "Generated.PSMetadataTest.Module" -TestApiName "psmetadatatest" `
-                        -TestSpecFileName "PsMetadataModuleTest.json"  `
-                        -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
+            -TestSpecFileName "PsMetadataModuleTest.json"  `
+            -PsSwaggerPath (Join-Path -Path $PSScriptRoot -ChildPath ".." | Join-Path -ChildPath "PSSwagger") -TestRootPath $PSScriptRoot
 
         # Import generated module
         Write-Verbose "Importing modules"
         Import-Module (Join-Path -Path $PSScriptRoot -ChildPath "Generated" | `
-                       Join-Path -ChildPath "Generated.PSMetadataTest.Module")
+                Join-Path -ChildPath "Generated.PSMetadataTest.Module")
         if ($global:PSSwaggerTest_EnableTracing -and $script:EnableTracer) {
             $script:EnableTracer = $false
             {
@@ -863,7 +863,7 @@ Describe "PSMetadataTests" -Tag @('PSMetadata','ScenarioTest')  {
     }
 }
 
-Describe "Header scenario tests" -Tag @('Header','ScenarioTest')  {
+Describe "Header scenario tests" -Tag @('Header', 'ScenarioTest') {
     BeforeAll {
         $PsSwaggerPath = Split-Path -Path $PSScriptRoot -Parent | Join-Path -ChildPath "PSSwagger"
         Import-Module $PsSwaggerPath -Force
@@ -881,12 +881,13 @@ Describe "Header scenario tests" -Tag @('Header','ScenarioTest')  {
         $ModuleVersion = '1.1.1.1'
         $GeneratedModuleVersionPath = Join-Path -Path $GeneratedModuleBase -ChildPath $ModuleVersion
         $Header = '__Custom_HEADER_Content__'
-        if((Get-Variable -Name PSEdition -ErrorAction Ignore) -and ('Core' -eq $PSEdition)) {
+        if ((Get-Variable -Name PSEdition -ErrorAction Ignore) -and ('Core' -eq $PSEdition)) {
             & "$env:SystemRoot\System32\WindowsPowerShell\v1.0\PowerShell.exe" -command "& {`$env:PSModulePath=`$env:PSModulePath_Backup;
                 Import-Module '$PsSwaggerPath' -Force -ArgumentList `$true;
                 New-PSSwaggerModule -SpecificationPath '$SwaggerSpecPath' -Name $ModuleName -Version '$ModuleVersion' -UseAzureCsharpGenerator -Path '$GeneratedPath' -NoAssembly -Verbose -ConfirmBootstrap -Header '$Header';
             }"
-        } else {
+        }
+        else {
             New-PSSwaggerModule -SpecificationPath $SwaggerSpecPath -Name $ModuleName -Version $ModuleVersion -UseAzureCsharpGenerator -Path $GeneratedPath -NoAssembly -Verbose -ConfirmBootstrap -Header $Header
         }
 
@@ -902,12 +903,13 @@ Describe "Header scenario tests" -Tag @('Header','ScenarioTest')  {
     It "Validate header comment from x-ms-code-generation-settings in the PSSwagger generated files" {
         $ModuleVersion = '2.2.2.2'
         $GeneratedModuleVersionPath = Join-Path -Path $GeneratedModuleBase -ChildPath $ModuleVersion
-        if((Get-Variable -Name PSEdition -ErrorAction Ignore) -and ('Core' -eq $PSEdition)) {
+        if ((Get-Variable -Name PSEdition -ErrorAction Ignore) -and ('Core' -eq $PSEdition)) {
             & "$env:SystemRoot\System32\WindowsPowerShell\v1.0\PowerShell.exe" -command "& {`$env:PSModulePath=`$env:PSModulePath_Backup;
                 Import-Module '$PsSwaggerPath' -Force -ArgumentList `$true;
                 New-PSSwaggerModule -SpecificationPath '$SwaggerSpecPath' -Name $ModuleName -Version '$ModuleVersion' -UseAzureCsharpGenerator -Path '$GeneratedPath' -NoAssembly -Verbose -ConfirmBootstrap;
             }"
-        } else {
+        }
+        else {
             New-PSSwaggerModule -SpecificationPath $SwaggerSpecPath -Name $ModuleName -Version $ModuleVersion -UseAzureCsharpGenerator -Path $GeneratedPath -NoAssembly -Verbose -ConfirmBootstrap
         }
         
@@ -922,7 +924,7 @@ Describe "Header scenario tests" -Tag @('Header','ScenarioTest')  {
     }
 }
 
-Describe "Pre-compiled SDK Assmebly scenario tests" -Tag @('SDKAssembly','ScenarioTest')  {    
+Describe "Pre-compiled SDK Assmebly scenario tests" -Tag @('SDKAssembly', 'ScenarioTest') {    
     BeforeAll {
         $PsSwaggerPath = Split-Path -Path $PSScriptRoot -Parent | Join-Path -ChildPath "PSSwagger"
         Import-Module $PsSwaggerPath -Force
@@ -1130,7 +1132,7 @@ Describe "Pre-compiled SDK Assmebly scenario tests" -Tag @('SDKAssembly','Scenar
     }
 }
 
-Describe "Output type scenario tests" -Tag @('OutputType','ScenarioTest')  {
+Describe "Output type scenario tests" -Tag @('OutputType', 'ScenarioTest') {
     BeforeAll {
         $ModuleName = 'Generated.AzExt.OutputType.Module'
         $SwaggerSpecPath = Join-Path -Path $PSScriptRoot -ChildPath 'Data' | Join-Path -ChildPath 'AzureExtensions' | Join-Path -ChildPath 'AzureExtensionsSpec.json'
@@ -1159,7 +1161,7 @@ Describe "Output type scenario tests" -Tag @('OutputType','ScenarioTest')  {
     }
 }
 
-Describe 'New-PSSwaggerModule cmdlet parameter tests' -Tag @('CmdletParameterTest','ScenarioTest')  {
+Describe 'New-PSSwaggerModule cmdlet parameter tests' -Tag @('CmdletParameterTest', 'ScenarioTest') {
     BeforeAll {
         $ModuleName = 'Generated.Module.NoVersionFolder'
         $SwaggerSpecPath = Join-Path -Path $PSScriptRoot -ChildPath 'Data' | Join-Path -ChildPath 'AzureExtensions' | Join-Path -ChildPath 'AzureExtensionsSpec.json'
@@ -1184,5 +1186,135 @@ Describe 'New-PSSwaggerModule cmdlet parameter tests' -Tag @('CmdletParameterTes
 
         $ModuleInfo = Import-Module $GeneratedModuleBase -Force -PassThru
         $ModuleInfo.ModuleBase | Should Be $GeneratedModuleBase
+    }
+}
+
+Describe 'ResourceId and InputObject parameter set tests' -Tag @('InputObject', 'ResourceId', 'ScenarioTest') {
+    BeforeAll {
+        $ModuleName = 'Generated.Module.ArmResourceIdAndInputObject'
+        $SwaggerSpecPath = Join-Path -Path $PSScriptRoot -ChildPath 'Data' | Join-Path -ChildPath 'AzureSpecs' | Join-Path -ChildPath 'cosmos-db.json'
+        $GeneratedPath = Join-Path -Path $PSScriptRoot -ChildPath 'Generated'
+        $GeneratedModuleBase = Join-Path -Path $GeneratedPath -ChildPath $ModuleName
+        if (Test-Path -Path $GeneratedModuleBase -PathType Container) {
+            Remove-Item -Path $GeneratedModuleBase -Recurse -Force
+        }
+
+        $params = @{
+            SpecificationPath       = $SwaggerSpecPath
+            Name                    = $ModuleName
+            UseAzureCsharpGenerator = $true
+            Path                    = $GeneratedPath
+            ConfirmBootstrap        = $true
+            Verbose                 = $true
+        }
+        Invoke-NewPSSwaggerModuleCommand -NewPSSwaggerModuleParameters $params
+        Import-Module $GeneratedModuleBase -Force
+
+        $ExpectedCommandDetails = @{
+            'Get-DatabaseAccount'    = [ordered]@{
+                # Total parameter count includes the PowerShell default/common parameters.
+                ParameterSetsParameterCount = [ordered]@{
+                    'DatabaseAccounts_List'                = 11
+                    'DatabaseAccounts_ListByResourceGroup' = 12
+                    'DatabaseAccounts_Get'                 = 13
+                    'ResourceId_DatabaseAccounts_Get'      = 12
+                    'InputObject_DatabaseAccounts_Get'     = 12
+                }
+                InputObjectParameterSetName = 'InputObject_DatabaseAccounts_Get'
+                ResourceIdParameterSetName  = 'ResourceId_DatabaseAccounts_Get'
+                AccountNameParameterSetName = 'DatabaseAccounts_Get'
+            }
+
+            'New-DatabaseAccount'    = [ordered]@{
+                ParameterSetsParameterCount = [ordered]@{
+                    'DatabaseAccounts_CreateOrUpdate'             = 15
+                    'ResourceId_DatabaseAccounts_CreateOrUpdate'  = 14
+                    'InputObject_DatabaseAccounts_CreateOrUpdate' = 14
+                }
+                InputObjectParameterSetName = 'InputObject_DatabaseAccounts_CreateOrUpdate'
+                ResourceIdParameterSetName  = 'ResourceId_DatabaseAccounts_CreateOrUpdate'
+                AccountNameParameterSetName = 'DatabaseAccounts_CreateOrUpdate'
+            }
+
+            'Set-DatabaseAccount'    = [ordered]@{
+                ParameterSetsParameterCount = [ordered]@{
+                    'DatabaseAccounts_CreateOrUpdate'             = 15
+                    'ResourceId_DatabaseAccounts_CreateOrUpdate'  = 14
+                    'InputObject_DatabaseAccounts_CreateOrUpdate' = 14
+                }
+                InputObjectParameterSetName = 'InputObject_DatabaseAccounts_CreateOrUpdate'
+                ResourceIdParameterSetName  = 'ResourceId_DatabaseAccounts_CreateOrUpdate'
+                AccountNameParameterSetName = 'DatabaseAccounts_CreateOrUpdate'
+            }
+
+            'Update-DatabaseAccount' = [ordered]@{
+                ParameterSetsParameterCount = [ordered]@{
+                    'DatabaseAccounts_Patch'             = 15
+                    'ResourceId_DatabaseAccounts_Patch'  = 14
+                    'InputObject_DatabaseAccounts_Patch' = 14
+                }
+                InputObjectParameterSetName = 'InputObject_DatabaseAccounts_Patch'
+                ResourceIdParameterSetName  = 'ResourceId_DatabaseAccounts_Patch'
+                AccountNameParameterSetName = 'DatabaseAccounts_Patch'
+            }
+
+            'Remove-DatabaseAccount' = [ordered]@{
+                ParameterSetsParameterCount = [ordered]@{
+                    'DatabaseAccounts_Delete'             = 14
+                    'ResourceId_DatabaseAccounts_Delete'  = 13
+                    'InputObject_DatabaseAccounts_Delete' = 13
+                }
+                InputObjectParameterSetName = 'InputObject_DatabaseAccounts_Delete'
+                ResourceIdParameterSetName  = 'ResourceId_DatabaseAccounts_Delete'
+                AccountNameParameterSetName = 'DatabaseAccounts_Delete'
+            }
+        }
+    }
+
+    $ExpectedCommandDetails.GetEnumerator() | ForEach-Object {
+        $CmdletName = $_.Name
+        $CmdletDetails = $_.Value
+        $ParameterSetsParameterCount = $CmdletDetails.ParameterSetsParameterCount
+        $InputObjectParameterSetName = $CmdletDetails.InputObjectParameterSetName
+        $ResourceIdParameterSetName = $CmdletDetails.ResourceIdParameterSetName
+        $AccountNameParameterSetName = $CmdletDetails.AccountNameParameterSetName
+
+        It "Test ResourceName parameter and InputObject & ResourceId parameter sets of '$CmdletName' cmdlet" {
+            $CommandInfo = Get-Command -Module $ModuleName -Name $CmdletName
+
+            $CommandInfo.ParameterSets.Count | Should Be $ParameterSetsParameterCount.Keys.Count
+            
+            $ParameterSetsParameterCount.GetEnumerator() | ForEach-Object {
+                $CommandInfo.ParameterSets.Name -contains $_.Name | Should Be $true
+            }
+            $CommandInfo.ParameterSets | ForEach-Object {
+                $ParameterSetsParameterCount[$_.Name] | Should Be $_.Parameters.Count
+            }
+            
+            # InputObject parameter
+            $CommandInfo.Parameters.Keys -contains 'InputObject' | Should Be $true
+            $CommandInfo.Parameters.InputObject.ParameterType.ToString() | Should BeExactly 'Microsoft.PowerShell.Generated.Module.ArmResourceIdAndInputObject.v001.Models.DatabaseAccount'
+            $CommandInfo.Parameters.InputObject.ParameterSets.Keys.Count | Should Be 1
+            $CommandInfo.Parameters.InputObject.ParameterSets.Keys -contains $InputObjectParameterSetName | Should Be $true
+            $CommandInfo.Parameters.InputObject.Attributes.ValueFromPipeline | Should Be $true
+            $CommandInfo.Parameters.InputObject.Attributes.ValueFromPipelineByPropertyName | Should Be $false
+
+            # ResourceId parameter
+            $CommandInfo.Parameters.Keys -contains 'ResourceId' | Should Be $true
+            $CommandInfo.Parameters.ResourceId.ParameterType.ToString() | Should BeExactly 'System.String'
+            $CommandInfo.Parameters.ResourceId.ParameterSets.Keys.Count | Should Be 1
+            $CommandInfo.Parameters.ResourceId.ParameterSets.Keys -contains $ResourceIdParameterSetName | Should Be $true
+            $CommandInfo.Parameters.ResourceId.Attributes.ValueFromPipeline | Should Be $false
+            $CommandInfo.Parameters.ResourceId.Attributes.ValueFromPipelineByPropertyName | Should Be $true
+
+            # Name parameter with AccountName alias
+            $CommandInfo.Parameters.Keys -contains 'Name' | Should Be $true
+            $CommandInfo.Parameters.Name.ParameterType.ToString() | Should BeExactly 'System.String'
+            $CommandInfo.Parameters.Name.ParameterSets.Keys.Count | Should Be 1
+            $CommandInfo.Parameters.Name.ParameterSets.Keys -contains $AccountNameParameterSetName | Should Be $true
+            $CommandInfo.Parameters.Name.Attributes.ValueFromPipeline | Should Be $false
+            $CommandInfo.Parameters.Name.Attributes.ValueFromPipelineByPropertyName | Should Be $false
+            $CommandInfo.Parameters.Name.Aliases -contains 'AccountName' | Should Be $true
+        }
     }
 }

--- a/Tests/data/AzureSpecs/cosmos-db.json
+++ b/Tests/data/AzureSpecs/cosmos-db.json
@@ -1,0 +1,1158 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2015-04-08",
+    "title": "Cosmos DB",
+    "description": "Azure Cosmos DB Database Service Resource Provider REST API"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "Impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{accountName}": {
+      "get": {
+        "operationId": "DatabaseAccounts_Get",
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountGet": {
+            "parameters": {
+              "accountName": "ddb1",
+              "resourceGroupName": "rg1",
+              "api-version": "2015-04-08",
+              "subscriptionId": "subid"
+            },
+            "responses": {
+              "200": {
+                "body": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/ddb1",
+                  "name": "ddb1",
+                  "location": "West US",
+                  "type": "Microsoft.DocumentDB/databaseAccounts",
+                  "kind": "GlobalDocumentDB",
+                  "tags": {},
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "documentEndpoint": "https://ddb1.documents.azure.com:443/",
+                    "ipRangeFilter": "",
+                    "databaseAccountOfferType": "Standard",
+                    "consistencyPolicy": {
+                      "defaultConsistencyLevel": "Session",
+                      "maxIntervalInSeconds": 5,
+                      "maxStalenessPrefix": 100
+                    },
+                    "writeLocations": [
+                      {
+                        "id": "ddb1-eastus",
+                        "locationName": "East US",
+                        "documentEndpoint": "https://ddb1-eastus.documents.azure.com:443/",
+                        "provisioningState": "Succeeded",
+                        "failoverPriority": 0
+                      }
+                    ],
+                    "readLocations": [
+                      {
+                        "id": "ddb1-eastus",
+                        "locationName": "East US",
+                        "documentEndpoint": "https://ddb1-eastus.documents.azure.com:443/",
+                        "provisioningState": "Succeeded",
+                        "failoverPriority": 0
+                      }
+                    ],
+                    "failoverPolicies": [
+                      {
+                        "id": "ddb1-eastus",
+                        "locationName": "East US",
+                        "failoverPriority": 0
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieves the properties of an existing Azure Cosmos DB database account.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/accountNameParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The database account properties were retrieved successfully.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseAccount"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "patch": {
+        "operationId": "DatabaseAccounts_Patch",
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountPatch": {
+            "parameters": {
+              "accountName": "ddb1",
+              "resourceGroupName": "rg1",
+              "api-version": "2015-04-08",
+              "subscriptionId": "subid",
+              "updateParameters": {
+                "tags": {
+                  "dept": "finance"
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "body": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/ddb1",
+                  "name": "ddb1",
+                  "location": "West US",
+                  "type": "Microsoft.DocumentDB/databaseAccounts",
+                  "kind": "GlobalDocumentDB",
+                  "tags": {},
+                  "properties": {
+                    "provisioningState": "Succeeded",
+                    "documentEndpoint": "https://ddb1.documents.azure.com:443/",
+                    "ipRangeFilter": "",
+                    "databaseAccountOfferType": "Standard",
+                    "consistencyPolicy": {
+                      "defaultConsistencyLevel": "Session",
+                      "maxIntervalInSeconds": 5,
+                      "maxStalenessPrefix": 100
+                    },
+                    "writeLocations": [
+                      {
+                        "id": "ddb1-eastus",
+                        "locationName": "East US",
+                        "documentEndpoint": "https://ddb1-eastus.documents.azure.com:443/",
+                        "provisioningState": "Succeeded",
+                        "failoverPriority": 0
+                      }
+                    ],
+                    "readLocations": [
+                      {
+                        "id": "ddb1-eastus",
+                        "locationName": "East US",
+                        "documentEndpoint": "https://ddb1-eastus.documents.azure.com:443/",
+                        "provisioningState": "Succeeded",
+                        "failoverPriority": 0
+                      }
+                    ],
+                    "failoverPolicies": [
+                      {
+                        "id": "ddb1-eastus",
+                        "locationName": "East US",
+                        "failoverPriority": 0
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Patches the properties of an existing Azure Cosmos DB database account.",
+        "x-ms-long-running-operation": true,
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/accountNameParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "name": "updateParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DatabaseAccountPatchParameters"
+            },
+            "description": "The tags parameter to patch for the current database account."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The properties of the database account were patched successfully.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseAccount"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "put": {
+        "operationId": "DatabaseAccounts_CreateOrUpdate",
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountCreateMin": {
+            "parameters": {
+              "accountName": "ddb1",
+              "resourceGroupName": "rg1",
+              "api-version": "2015-04-08",
+              "subscriptionId": "subid",
+              "createUpdateParameters": {
+                "location": "westus",
+                "properties": {
+                  "databaseAccountOfferType": "Standard",
+                  "locations": [
+                    {
+                      "failoverPriority": 0,
+                      "locationName": "southcentralus"
+                    }
+                  ]
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "body": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/ddb1",
+                  "name": "ddb1",
+                  "location": "West US",
+                  "type": "Microsoft.DocumentDB/databaseAccounts",
+                  "kind": "GlobalDocumentDB",
+                  "tags": {},
+                  "properties": {
+                    "provisioningState": "Initializing",
+                    "ipRangeFilter": "",
+                    "databaseAccountOfferType": "Standard",
+                    "consistencyPolicy": {
+                      "defaultConsistencyLevel": "Session",
+                      "maxIntervalInSeconds": 5,
+                      "maxStalenessPrefix": 100
+                    },
+                    "writeLocations": [
+                      {
+                        "id": "ddb1-southcentralus",
+                        "locationName": "South Central US",
+                        "provisioningState": "Initializing",
+                        "failoverPriority": 0
+                      }
+                    ],
+                    "readLocations": [
+                      {
+                        "id": "ddb1-southcentralus",
+                        "locationName": "South Central US",
+                        "provisioningState": "Initializing",
+                        "failoverPriority": 0
+                      }
+                    ],
+                    "failoverPolicies": [
+                      {
+                        "id": "ddb1-southcentralus",
+                        "locationName": "South Central US",
+                        "failoverPriority": 0
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "CosmosDBDatabaseAccountCreateMax": {
+            "parameters": {
+              "accountName": "ddb1",
+              "resourceGroupName": "rg1",
+              "api-version": "2015-04-08",
+              "subscriptionId": "subid",
+              "createUpdateParameters": {
+                "location": "westus",
+                "tags": {},
+                "kind": "GlobalDocumentDB",
+                "properties": {
+                  "databaseAccountOfferType": "Standard",
+                  "ipRangeFilter": "10.10.10.10",
+                  "locations": [
+                    {
+                      "failoverPriority": 0,
+                      "locationName": "southcentralus"
+                    },
+                    {
+                      "failoverPriority": 1,
+                      "locationName": "eastus"
+                    }
+                  ],
+                  "consistencyPolicy": {
+                    "defaultConsistencyLevel": "BoundedStaleness",
+                    "maxIntervalInSeconds": 10,
+                    "maxStalenessPrefix": 200
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "body": {
+                  "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/ddb1",
+                  "name": "ddb1",
+                  "location": "West US",
+                  "type": "Microsoft.DocumentDB/databaseAccounts",
+                  "kind": "GlobalDocumentDB",
+                  "tags": {},
+                  "properties": {
+                    "provisioningState": "Initializing",
+                    "ipRangeFilter": "10.10.10.10",
+                    "databaseAccountOfferType": "Standard",
+                    "consistencyPolicy": {
+                      "defaultConsistencyLevel": "BoundedStaleness",
+                      "maxIntervalInSeconds": 10,
+                      "maxStalenessPrefix": 200
+                    },
+                    "writeLocations": [
+                      {
+                        "id": "ddb1-southcentralus",
+                        "locationName": "South Central US",
+                        "provisioningState": "Initializing",
+                        "failoverPriority": 0
+                      }
+                    ],
+                    "readLocations": [
+                      {
+                        "id": "ddb1-southcentralus",
+                        "locationName": "South Central US",
+                        "provisioningState": "Initializing",
+                        "failoverPriority": 0
+                      },
+                      {
+                        "id": "ddb1-eastus",
+                        "locationName": "East US",
+                        "provisioningState": "Initializing",
+                        "failoverPriority": 1
+                      }
+                    ],
+                    "failoverPolicies": [
+                      {
+                        "id": "ddb1-southcentralus",
+                        "locationName": "South Central US",
+                        "failoverPriority": 0
+                      },
+                      {
+                        "id": "ddb1-eastus",
+                        "locationName": "East US",
+                        "failoverPriority": 1
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Creates or updates an Azure Cosmos DB database account.",
+        "x-ms-long-running-operation": true,
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/accountNameParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "name": "createUpdateParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DatabaseAccountCreateUpdateParameters"
+            },
+            "description": "The parameters to provide for the current database account."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The database account create or update operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseAccount"
+            }
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      },
+      "delete": {
+        "operationId": "DatabaseAccounts_Delete",
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountDelete": {
+            "parameters": {
+              "accountName": "ddb1",
+              "resourceGroupName": "rg1",
+              "api-version": "2015-04-08",
+              "subscriptionId": "subid"
+            },
+            "responses": {
+              "202": {},
+              "204": {}
+            }
+          }
+        },
+        "description": "Deletes an existing Azure Cosmos DB database account.",
+        "x-ms-long-running-operation": true,
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/accountNameParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The database account delete operation will complete asynchronously."
+          },
+          "204": {
+            "description": "The specified account does not exist in the subscription."
+          }
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/databaseAccounts": {
+      "get": {
+        "operationId": "DatabaseAccounts_List",
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountList": {
+            "parameters": {
+              "api-version": "2015-04-08",
+              "subscriptionId": "subid"
+            },
+            "responses": {
+              "200": {
+                "body": {
+                  "value": [
+                    {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/ddb1",
+                      "name": "ddb1",
+                      "location": "West US",
+                      "type": "Microsoft.DocumentDB/databaseAccounts",
+                      "kind": "GlobalDocumentDB",
+                      "tags": {},
+                      "properties": {
+                        "provisioningState": "Succeeded",
+                        "documentEndpoint": "https://ddb1.documents.azure.com:443/",
+                        "ipRangeFilter": "",
+                        "databaseAccountOfferType": "Standard",
+                        "consistencyPolicy": {
+                          "defaultConsistencyLevel": "Session",
+                          "maxIntervalInSeconds": 5,
+                          "maxStalenessPrefix": 100
+                        },
+                        "writeLocations": [
+                          {
+                            "id": "ddb1-eastus",
+                            "locationName": "East US",
+                            "documentEndpoint": "https://ddb1-eastus.documents.azure.com:443/",
+                            "provisioningState": "Succeeded",
+                            "failoverPriority": 0
+                          }
+                        ],
+                        "readLocations": [
+                          {
+                            "id": "ddb1-eastus",
+                            "locationName": "East US",
+                            "documentEndpoint": "https://ddb1-eastus.documents.azure.com:443/",
+                            "provisioningState": "Succeeded",
+                            "failoverPriority": 0
+                          }
+                        ],
+                        "failoverPolicies": [
+                          {
+                            "id": "ddb1-eastus",
+                            "locationName": "East US",
+                            "failoverPriority": 0
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Lists all the Azure Cosmos DB database accounts available under the subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseAccountsListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": null
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts": {
+      "get": {
+        "operationId": "DatabaseAccounts_ListByResourceGroup",
+        "x-ms-examples": {
+          "CosmosDBDatabaseAccountListByResourceGroup": {
+            "parameters": {
+              "api-version": "2015-04-08",
+              "resourceGroupName": "rg1",
+              "subscriptionId": "subid"
+            },
+            "responses": {
+              "200": {
+                "body": {
+                  "value": [
+                    {
+                      "id": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.DocumentDB/databaseAccounts/ddb1",
+                      "name": "ddb1",
+                      "location": "West US",
+                      "type": "Microsoft.DocumentDB/databaseAccounts",
+                      "kind": "GlobalDocumentDB",
+                      "tags": {},
+                      "properties": {
+                        "provisioningState": "Succeeded",
+                        "documentEndpoint": "https://ddb1.documents.azure.com:443/",
+                        "ipRangeFilter": "",
+                        "databaseAccountOfferType": "Standard",
+                        "consistencyPolicy": {
+                          "defaultConsistencyLevel": "Session",
+                          "maxIntervalInSeconds": 5,
+                          "maxStalenessPrefix": 100
+                        },
+                        "writeLocations": [
+                          {
+                            "id": "ddb1-eastus",
+                            "locationName": "East US",
+                            "documentEndpoint": "https://ddb1-eastus.documents.azure.com:443/",
+                            "provisioningState": "Succeeded",
+                            "failoverPriority": 0
+                          }
+                        ],
+                        "readLocations": [
+                          {
+                            "id": "ddb1-eastus",
+                            "locationName": "East US",
+                            "documentEndpoint": "https://ddb1-eastus.documents.azure.com:443/",
+                            "provisioningState": "Succeeded",
+                            "failoverPriority": 0
+                          }
+                        ],
+                        "failoverPolicies": [
+                          {
+                            "id": "ddb1-eastus",
+                            "locationName": "East US",
+                            "failoverPriority": 0
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Lists all the Azure Cosmos DB database accounts available under the given resource group.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/apiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/subscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DatabaseAccountsListResult"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": null
+        },
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "DatabaseAccountsListResult": {
+      "properties": {
+        "value": {
+          "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DatabaseAccount"
+          },
+          "description": "List of database account and their properties."
+        }
+      },
+      "description": "The List operation response, that contains the database accounts and their properties."
+    },
+    "FailoverPolicies": {
+      "properties": {
+        "failoverPolicies": {
+          "type": "array",
+          "description": "List of failover policies.",
+          "items": {
+            "$ref": "#/definitions/FailoverPolicy"
+          }
+        }
+      },
+      "description": "The list of new failover policies for the failover priority change."
+    },
+    "FailoverPolicy": {
+      "type": "object",
+      "description": "The failover policy for a given region of a database account.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The unique identifier of the region in which the database account replicates to. Example: &lt;accountName&gt;-&lt;locationName&gt;."
+        },
+        "locationName": {
+          "type": "string",
+          "description": "The name of the region in which the database account exists."
+        },
+        "failoverPriority": {
+          "type": "integer",
+          "minimum": 0,
+          "format": "int32",
+          "description": "The failover priority of the region. A failover priority of 0 indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists."
+        }
+      }
+    },
+    "Location": {
+      "description": "A region in which the Azure Cosmos DB database account is deployed.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The unique identifier of the region within the database account. Example: &lt;accountName&gt;-&lt;locationName&gt;."
+        },
+        "locationName": {
+          "type": "string",
+          "description": "The name of the region."
+        },
+        "documentEndpoint": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The connection endpoint for the specific region. Example: https://&lt;accountName&gt;-&lt;locationName&gt;.documents.azure.com:443/"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState"
+        },
+        "failoverPriority": {
+          "description": "The failover priority of the region. A failover priority of 0 indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists.",
+          "format": "int32",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "Resource": {
+      "type": "object",
+      "description": "A database account resource.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The unique resource identifier of the database account."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The name of the database account."
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The type of Azure resource."
+        },
+        "location": {
+          "type": "string",
+          "description": "The location of the resource group to which the resource belongs."
+        },
+        "tags": {
+          "$ref": "#/definitions/Tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "x-ms-azure-resource": true
+    },
+    "DatabaseAccount": {
+      "description": "An Azure Cosmos DB database account.",
+      "type": "object",
+      "properties": {
+        "kind": {
+          "description": "Indicates the type of database account. This can only be set at database account creation.",
+          "type": "string",
+          "default": "GlobalDocumentDB",
+          "enum": [
+            "GlobalDocumentDB",
+            "MongoDB",
+            "Parse"
+          ],
+          "x-ms-enum": {
+            "name": "DatabaseAccountKind",
+            "modelAsString": true
+          }
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/DatabaseAccountProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ]
+    },
+    "ConsistencyPolicy": {
+      "type": "object",
+      "description": "The consistency policy for the Cosmos DB database account.",
+      "properties": {
+        "defaultConsistencyLevel": {
+          "description": "The default consistency level and configuration settings of the Cosmos DB account.",
+          "type": "string",
+          "enum": [
+            "Eventual",
+            "Session",
+            "BoundedStaleness",
+            "Strong",
+            "ConsistentPrefix"
+          ],
+          "x-ms-enum": {
+            "name": "DefaultConsistencyLevel",
+            "modelAsString": false
+          }
+        },
+        "maxStalenessPrefix": {
+          "description": "When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483647,
+          "format": "int64"
+        },
+        "maxIntervalInSeconds": {
+          "description": "When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 1 - 100. Required when defaultConsistencyPolicy is set to 'BoundedStaleness'.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "format": "int32"
+        }
+      },
+      "required": [
+        "defaultConsistencyLevel"
+      ]
+    },
+    "DatabaseAccountProperties": {
+      "description": "Properties for the database account.",
+      "type": "object",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState"
+        },
+        "documentEndpoint": {
+          "description": "The connection endpoint for the Cosmos DB database account.",
+          "type": "string",
+          "readOnly": true
+        },
+        "databaseAccountOfferType": {
+          "description": "The offer type for the Cosmos DB database account. Default value: Standard.",
+          "readOnly": true,
+          "$ref": "#/definitions/DatabaseAccountOfferType"
+        },
+        "ipRangeFilter": {
+          "description": "Cosmos DB Firewall Support: This value specifies the set of IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IPs for a given database account. IP addresses/ranges must be comma separated and must not contain any spaces.",
+          "$ref": "#/definitions/IPRangeFilter"
+        },
+        "enableAutomaticFailover": {
+          "description": "Enables automatic failover of the write region in the rare event that the region is unavailable due to an outage. Automatic failover will result in a new write region for the account and is chosen based on the failover priorities configured for the account.",
+          "type": "boolean"
+        },
+        "consistencyPolicy": {
+          "description": "The consistency policy for the Cosmos DB database account.",
+          "$ref": "#/definitions/ConsistencyPolicy"
+        },
+        "writeLocations": {
+          "type": "array",
+          "readOnly": true,
+          "description": "An array that contains the write location for the Cosmos DB account.",
+          "items": {
+            "$ref": "#/definitions/Location"
+          }
+        },
+        "readLocations": {
+          "type": "array",
+          "readOnly": true,
+          "description": "An array that contains of the read locations enabled for the Cosmos DB account.",
+          "items": {
+            "$ref": "#/definitions/Location"
+          }
+        },
+        "failoverPolicies": {
+          "type": "array",
+          "readOnly": true,
+          "description": "An array that contains the regions ordered by their failover priorities.",
+          "items": {
+            "$ref": "#/definitions/FailoverPolicy"
+          }
+        }
+      }
+    },
+    "DatabaseAccountCreateUpdateProperties": {
+      "description": "Properties to create and update Azure Cosmos DB database accounts.",
+      "type": "object",
+      "properties": {
+        "consistencyPolicy": {
+          "description": "The consistency policy for the Cosmos DB account.",
+          "$ref": "#/definitions/ConsistencyPolicy"
+        },
+        "locations": {
+          "type": "array",
+          "description": "An array that contains the georeplication locations enabled for the Cosmos DB account.",
+          "items": {
+            "$ref": "#/definitions/Location"
+          }
+        },
+        "databaseAccountOfferType": {
+          "$ref": "#/definitions/DatabaseAccountOfferType"
+        },
+        "ipRangeFilter": {
+          "description": "Cosmos DB Firewall Support: This value specifies the set of IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IPs for a given database account. IP addresses/ranges must be comma separated and must not contain any spaces.",
+          "$ref": "#/definitions/IPRangeFilter"
+        },
+        "enableAutomaticFailover": {
+          "description": "Enables automatic failover of the write region in the rare event that the region is unavailable due to an outage. Automatic failover will result in a new write region for the account and is chosen based on the failover priorities configured for the account.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "locations",
+        "databaseAccountOfferType"
+      ]
+    },
+    "DatabaseAccountCreateUpdateParameters": {
+      "description": "Parameters to create and update Cosmos DB database accounts.",
+      "type": "object",
+      "properties": {
+        "kind": {
+          "description": "Indicates the type of database account. This can only be set at database account creation.",
+          "type": "string",
+          "default": "GlobalDocumentDB",
+          "enum": [
+            "GlobalDocumentDB",
+            "MongoDB",
+            "Parse"
+          ],
+          "x-ms-enum": {
+            "name": "DatabaseAccountKind",
+            "modelAsString": true
+          }
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/DatabaseAccountCreateUpdateProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "required": [
+        "properties"
+      ]
+    },
+    "DatabaseAccountPatchParameters": {
+      "description": "Parameters for patching Azure Cosmos DB database account properties.",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "$ref": "#/definitions/Tags"
+        }
+      }
+    },
+    "DatabaseAccountListReadOnlyKeysResult": {
+      "description": "The read-only access keys for the given database account.",
+      "properties": {
+        "primaryReadonlyMasterKey": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Base 64 encoded value of the primary read-only key."
+        },
+        "secondaryReadonlyMasterKey": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Base 64 encoded value of the secondary read-only key."
+        }
+      }
+    },
+    "DatabaseAccountListKeysResult": {
+      "description": "The access keys for the given database account.",
+      "properties": {
+        "primaryMasterKey": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Base 64 encoded value of the primary read-write key."
+        },
+        "secondaryMasterKey": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Base 64 encoded value of the secondary read-write key."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/DatabaseAccountListReadOnlyKeysResult"
+        }
+      }
+    },
+    "DatabaseAccountConnectionString": {
+      "description": "Connection string for the Cosmos DB account",
+      "properties": {
+        "connectionString": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Value of the connection string"
+        },
+        "description": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Description of the connection string"
+        }
+      }
+    },
+    "DatabaseAccountListConnectionStringsResult": {
+      "description": "The connection strings for the given database account.",
+      "properties": {
+        "connectionStrings": {
+          "type": "array",
+          "description": "An array that contains the connection strings for the Cosmos DB account.",
+          "items": {
+            "$ref": "#/definitions/DatabaseAccountConnectionString"
+          }
+        }
+      }
+    },
+    "DatabaseAccountRegenerateKeyParameters": {
+      "type": "object",
+      "description": "Parameters to regenerate the keys within the database account.",
+      "properties": {
+        "keyKind": {
+          "type": "string",
+          "description": "The access key to regenerate.",
+          "enum": [
+            "primary",
+            "secondary",
+            "primaryReadonly",
+            "secondaryReadonly"
+          ],
+          "x-ms-enum": {
+            "name": "KeyKind",
+            "modelAsString": true
+          }
+        }
+      },
+      "required": [
+        "keyKind"
+      ]
+    },
+    "DatabaseAccountOfferType": {
+      "description": "The offer type for the Cosmos DB database account.",
+      "type": "string",
+      "enum": [
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "DatabaseAccountOfferType",
+        "modelAsString": false
+      }
+    },
+    "Tags": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Tags are a list of key-value pairs that describe the resource. These tags can be used in viewing and grouping this resource (across resource groups). A maximum of 15 tags can be provided for a resource. Each tag must have a key no greater than 128 characters and value no greater than 256 characters."
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "readOnly": true,
+      "description": "The status of the Cosmos DB account at the time the operation was called. The status can be one of following. 'Creating' – the Cosmos DB account is being created. When an account is in Creating state, only properties that are specified as input for the Create Cosmos DB account operation are returned. 'Succeeded' – the Cosmos DB account is active for use. 'Updating' – the Cosmos DB account is being updated. 'Deleting' – the Cosmos DB account is being deleted. 'Failed' – the Cosmos DB account failed creation."
+    },
+    "IPRangeFilter": {
+      "type": "string",
+      "description": "Cosmos DB Firewall Support: This value specifies the set of IP addresses or IP address ranges in CIDR form to be included as the allowed list of client IPs for a given database account. IP addresses/ranges must be comma separated and must not contain any spaces."
+    },
+    "Operation": {
+      "description": "REST API operation",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Operation name: {provider}/{resource}/{operation}",
+          "type": "string"
+        },
+        "display": {
+          "description": "The object that represents the operation.",
+          "properties": {
+            "Provider": {
+              "description": "Service provider: Microsoft.ResourceProvider",
+              "type": "string"
+            },
+            "Resource": {
+              "description": "Resource on which the operation is performed: Profile, endpoint, etc.",
+              "type": "string"
+            },
+            "Operation": {
+              "description": "Operation type: Read, write, delete, etc.",
+              "type": "string"
+            },
+            "Description": {
+              "description": "Description of operation",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "OperationListResult": {
+      "description": "Result of the request to list Resource Provider operations. It contains a list of operations and a URL link to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          },
+          "description": "List of operations supported by the Resource Provider."
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of operation list results if there are any."
+        }
+      }
+    }
+  },
+  "parameters": {
+    "subscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "Azure subscription ID.",
+      "required": true,
+      "type": "string"
+    },
+    "apiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Version of the API to be used with the client request. The current version is 2015-04-08."
+    },
+    "resourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "pattern": "^[-\\w\\._\\(\\)]+$",
+      "minLength": 1,
+      "maxLength": 90,
+      "x-ms-parameter-location": "method",
+      "description": "Name of an Azure resource group."
+    },
+    "accountNameParameter": {
+      "name": "accountName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "description": "Cosmos DB database account name.",
+      "minLength": 3,
+      "maxLength": 50
+    }
+  }
+}

--- a/docs/commands/New-PSSwaggerModule.md
+++ b/docs/commands/New-PSSwaggerModule.md
@@ -141,7 +141,7 @@ Accept wildcard characters: False
 ### -AssemblyFileName
 File name of the pre-compiled SDK assembly.
 This assembly along with its dependencies should be available in '.\ref\fullclr\' folder under the target module version base path ($Path\$Name\$Version\\).
-If your generated module needs to work on PowerShell Core, place the coreclr assembly along with its depdencies under '.\ref\coreclr\' folder under the target module version base path ($Path\$Name\$Version\\).
+If your generated module needs to work on PowerShell Core, place the coreclr assembly along with its dependencies under '.\ref\coreclr\' folder under the target module version base path ($Path\$Name\$Version\\).
 For FullClr, the specified assembly should be available at "$Path\$Name\$Version\ref\fullclr\$AssemblyFileName".
 For CoreClr, the specified assembly should be available at "$Path\$Name\$Version\ref\coreclr\$AssemblyFileName".
 
@@ -280,6 +280,13 @@ Accept wildcard characters: False
 ### -UseAzureCsharpGenerator
 Switch to specify whether AzureCsharp code generator is required.
 By default, this command uses CSharp code generator.
+
+When this switch is specified and the resource id follows the guidelines of Azure Resource operations
+- The following additional parameter sets will be generated
+  - InputObject parameter set with the same object type returned by Get.
+Supports piping from Get operarion to action cmdlets.
+  - ResourceId parameter set which splits the resource id into component parts (supports piping from generic cmdlets).
+- Parameter name of Azure resource name parameter will be generated as 'Name' and the actual resource name parameter from the resource id will be added as an alias.
 
 ```yaml
 Type: SwitchParameter

--- a/docs/commands/New-PSSwaggerModule.md
+++ b/docs/commands/New-PSSwaggerModule.md
@@ -28,17 +28,18 @@ New-PSSwaggerModule -SpecificationPath <String> -Path <String> -AssemblyFileName
 
 ### SdkAssemblyWithSpecificationUri
 ```
-New-PSSwaggerModule -SpecificationUri <Uri> [-Credential <PSCredential>] [-UseDefaultCredential] -Path <String> -AssemblyFileName <String>
- [-ClientTypeName <String>] [-ModelsName <String>] -Name <String> [-Version <Version>] [-NoVersionFolder]
- [-DefaultCommandPrefix <String>] [-Header <String[]>] [-UseAzureCsharpGenerator]
+New-PSSwaggerModule -SpecificationUri <Uri> [-Credential <PSCredential>] [-UseDefaultCredential] -Path <String>
+ -AssemblyFileName <String> [-ClientTypeName <String>] [-ModelsName <String>] -Name <String>
+ [-Version <Version>] [-NoVersionFolder] [-DefaultCommandPrefix <String>] [-Header <String[]>]
+ [-UseAzureCsharpGenerator]
 ```
 
 ### SpecificationUri
 ```
-New-PSSwaggerModule -SpecificationUri <Uri> [-Credential <PSCredential>] [-UseDefaultCredential] -Path <String> -Name <String> [-Version <Version>]
- [-NoVersionFolder] [-DefaultCommandPrefix <String>] [-Header <String[]>] [-UseAzureCsharpGenerator]
- [-NoAssembly] [-PowerShellCorePath <String>] [-IncludeCoreFxAssembly] [-InstallToolsForAllUsers] [-TestBuild]
- [-SymbolPath <String>] [-ConfirmBootstrap]
+New-PSSwaggerModule -SpecificationUri <Uri> [-Credential <PSCredential>] [-UseDefaultCredential] -Path <String>
+ -Name <String> [-Version <Version>] [-NoVersionFolder] [-DefaultCommandPrefix <String>] [-Header <String[]>]
+ [-UseAzureCsharpGenerator] [-NoAssembly] [-PowerShellCorePath <String>] [-IncludeCoreFxAssembly]
+ [-InstallToolsForAllUsers] [-TestBuild] [-SymbolPath <String>] [-ConfirmBootstrap]
 ```
 
 ## DESCRIPTION
@@ -93,7 +94,7 @@ Accept wildcard characters: False
 ```
 
 ### -Credential
-Credentials to use when the SpecificationUri requires authentification. Will override -UseDefaultCredential when both are specified at the same time.
+Credential to use when the SpecificationUri requires authentication.
 
 ```yaml
 Type: PSCredential
@@ -107,9 +108,9 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-
 ### -UseDefaultCredential
-Use default credentials to download the SpecificationUri. Overridden by -Credential when both are specified at the same time.
+Use default credentials to download the SpecificationUri.
+Overridden by -Credential when both are specified at the same time.
 
 ```yaml
 Type: SwitchParameter

--- a/docs/commands/New-PSSwaggerModule.md
+++ b/docs/commands/New-PSSwaggerModule.md
@@ -95,6 +95,7 @@ Accept wildcard characters: False
 
 ### -Credential
 Credential to use when the SpecificationUri requires authentication.
+It will override -UseDefaultCredential when both are specified at the same time.
 
 ```yaml
 Type: PSCredential


### PR DESCRIPTION
Added support for generating ResourceId and InputObject parameter sets, along with 'Name' as the ResourceName parameter name for AzureRM swagger specs.

For AzureRM swagger specs, when UseAzureCsharpGenerator switch is specified and the resource id follows the guidelines of Azure Resource operations:
- The following additional parameter sets will be generated
    - InputObject parameter set with the same object type returned by Get. Supports piping from Get operarion to action cmdlets.
    - ResourceId parameter set which splits the resource id into component parts (supports piping from generic cmdlets).
- Parameter name of Azure resource name parameter will be generated as 'Name' and the actual resource name parameter from the resource id will be added as an alias.

The following pipeline operations are manually validated for the Azure CosmosDB RP.
```powershell
# -Name parameter for ResourceName
$DatabaseAccount = Get-DatabaseAccount -Name $ExistingAccountName -ResourceGroupName $ResourceGroupName -Verbose
# -AccountName parameter which is an alias to Name parameter
$DatabaseAccount = Get-DatabaseAccount -AccountName $ExistingAccountName -ResourceGroupName $ResourceGroupName

# ResourceId parameter set
Get-DatabaseAccount -ResourceId $DatabaseAccount.Id
# ResourceId parameter set by piping the output generic Get-AzureRmResource cmdlet
Get-AzureRmResource -ResourceId $DatabaseAccount.Id | Get-DatabaseAccount

# InputObject parameter set
Get-DatabaseAccount -InputObject $DatabaseAccount
# InputObject parameter set by piping the DatabaseAccount object
$DatabaseAccount | Get-DatabaseAccount
```