### PR TITLE
Fixing references to version variable

### DIFF
--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -519,8 +519,8 @@ function New-PSSwaggerModule {
         $ModuleNameandVersionFolder = Join-Path -Path $Name -ChildPath $Version
 
         if ($outputDirectory.EndsWith($Name, [System.StringComparison]::OrdinalIgnoreCase)) {
-            $outputDirectory = Join-Path -Path $outputDirectory -ChildPath $ModuleVersion
-            $SymbolPath = Join-Path -Path $SymbolPath -ChildPath $ModuleVersion
+            $outputDirectory = Join-Path -Path $outputDirectory -ChildPath $Version
+            $SymbolPath = Join-Path -Path $SymbolPath -ChildPath $Version
         }
         elseif (-not $outputDirectory.EndsWith($ModuleNameandVersionFolder, [System.StringComparison]::OrdinalIgnoreCase)) {
             $outputDirectory = Join-Path -Path $outputDirectory -ChildPath $ModuleNameandVersionFolder


### PR DESCRIPTION
I downloaded and installed PSSwagger 0.3.0 from PSGallery and got the following (non-fatal) error trying to generate a new module:

```
The variable '$ModuleVersion' cannot be retrieved because it has not been set.
At C:\Users\xxx\Documents\WindowsPowerShell\Modules\PSSwagger\0.3.0\PSSwagger.psm1:468 char:76
+ ... irectory = Join-Path -Path $outputDirectory -ChildPath $ModuleVersion
+                                                            ~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (ModuleVersion:String) [], RuntimeException
    + FullyQualifiedErrorId : VariableIsUndefined

The variable '$ModuleVersion' cannot be retrieved because it has not been set.
At C:\Users\xxx\Documents\WindowsPowerShell\Modules\PSSwagger\0.3.0\PSSwagger.psm1:469 char:66
+ ...   $SymbolPath = Join-Path -Path $SymbolPath -ChildPath $ModuleVersion
+                                                            ~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (ModuleVersion:String) [], RuntimeException
    + FullyQualifiedErrorId : VariableIsUndefined
```

I tracked down the error to those lines, which referenced a nonexistent `$ModuleVersion` variable.  I changed the references to `$Version`, which appears to create the directories properly.  I then forked the repo and made the fixes here on this branch.

Please do not hesitate to contact me if you have any questions or concerns, or if you need me to make additional changes and fixes before this PR can be accepted.

Thanks,
\# Chris

