### PR TITLE
Check for correct csc version, handle hyphens in operation ID

### DIFF
--- a/PSSwagger/PSSwagger.Resources.psd1
+++ b/PSSwagger/PSSwagger.Resources.psd1
@@ -26,6 +26,7 @@ ConvertFrom-StringData @'
     DataTypeNotImplemented=Please get an implementation of '{0}' for '{1}'
     AutoRestNotInPath=Unable to find AutoRest in PATH environment. Ensure the PATH is updated.
     CscExeNotInPath=Unable to find CSC.exe in PATH environment. Ensure the PATH is updated with CSC.exe location.
+    IncorrectVersionOfCscExeInPath=The first CSC.exe in the PATH environment variable is the compiler included with Windows or the .NET framework. Please use the Microsoft.Net.Compilers package which contains the Roslyn CSC.exe, and ensure that package's CSC.exe comes first in your PATH environment variable.
     AutoRestError=AutoRest resulted in an error
     SwaggerParamsMissing=No parameters in the Swagger
     SwaggerDefinitionsMissing=No definitions in the Swagger

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -803,9 +803,41 @@ function ConvertTo-CsharpCode {
         throw $LocalizedData.AutoRestNotInPath
     }
 
-    if (-not (Get-OperatingSystemInfo).IsCore -and 
-        (-not (Get-Command -Name 'Csc.Exe' -ErrorAction Ignore))) {
-        throw $LocalizedData.CscExeNotInPath
+    if (-not (Get-OperatingSystemInfo).IsCore) {
+        if (-not (Get-Command -Name 'Csc.Exe' -ErrorAction Ignore)) {
+            throw $LocalizedData.CscExeNotInPath
+        }
+
+        $csc = Get-Command -Name 'Csc.Exe'
+        # The compiler Roslyn compiler is managed while the in-box compiler is native
+        # There's a better way to read the PE header using seeks but this is fine
+        [byte[]]$data = New-Object -TypeName byte[] -ArgumentList 4096
+        $fs = [System.IO.File]::OpenRead($csc.Source)
+        try {
+            $fs.Read($data, 0, 4096)
+        } finally {
+            $fs.Dispose()
+        }
+
+        # Last 4 bytes of the 64-byte IMAGE_DOS_HEADER is pointer to IMAGE_NT_HEADER
+        $p_inh = [System.BitConverter]::ToUInt32($data, 60)
+        # Skip past 4 byte signature + 20 byte IMAGE_FILE_HEADER to get to IMAGE_OPTIONAL_HEADER
+        $p_ioh = $p_inh + 24
+        # Grab the magic header to determine 32-bit or 64-bit
+        $magic = [System.BitConverter]::ToUInt16($data, [int]$p_ioh)
+        if ($magic -eq 0x20b) {
+            # Skip to the end of IMAGE_OPTIONAL_HEADER64 to the first entry in the data directory array
+            $p_dataDirectory0 = [System.BitConverter]::ToUInt32($data, [int]$p_ioh + 224)
+        } else {
+            # Same thing, but for IMAGE_OPTIONAL_HEADER32
+            $p_dataDirectory0 = [System.BitConverter]::ToUInt32($data, [int]$p_ioh + 208)
+        }
+
+        if ($p_dataDirectory0 -eq 0) {
+            # If there is no entry, this is a native exe
+            # That means this is the in-box csc, which is not supported
+            throw $LocalizedData.IncorrectVersionOfCscExeInPath
+        }
     }
 
     $outputDirectory = $SwaggerMetaDict['outputDirectory']

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -814,7 +814,7 @@ function ConvertTo-CsharpCode {
         [byte[]]$data = New-Object -TypeName byte[] -ArgumentList 4096
         $fs = [System.IO.File]::OpenRead($csc.Source)
         try {
-            $fs.Read($data, 0, 4096)
+            $null = $fs.Read($data, 0, 4096)
         } finally {
             $fs.Dispose()
         }

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -1263,11 +1263,12 @@ function Set-ExtendedCodeMetadata {
             $operationsWithSuffix = ''
             $opIdValues = $operationId -split '_',2 
             if(-not $opIdValues -or ($opIdValues.count -ne 2)) {
-                $methodNames += $operationId + 'WithHttpMessagesAsync'
-                $methodNames += $operationId + 'Method' + 'WithHttpMessagesAsync'
+                # I'm sure there's other stuff but what? Need to check what AutoRest is using. Their CSharpNamer thing?
+                $methodNames += $operationId.Replace("-", "") + 'WithHttpMessagesAsync'
+                $methodNames += $operationId.Replace("-", "") + 'Method' + 'WithHttpMessagesAsync'
             } else {            
-                $operationName = $opIdValues[0]
-                $operationType = $opIdValues[1]
+                $operationName = $opIdValues[0].Replace("-", "")
+                $operationType = $opIdValues[1].Replace("-", "")
                 $operations = ".$operationName"
                 if ($parameterSetDetail['UseOperationsSuffix'] -and $parameterSetDetail['UseOperationsSuffix'])
                 { 


### PR DESCRIPTION
Fixes:
- Hyphens in operation ID causing unexpected client method name

Features:
- Validate the version of csc (in-box vs. NuGet) by checking native vs. managed