### PR TITLE
Client-side filtering

### DIFF
--- a/PSSwagger/Get-ApplicableFilters.ps1
+++ b/PSSwagger/Get-ApplicableFilters.ps1
@@ -6,7 +6,7 @@ Microsoft.PowerShell.Core\Set-StrictMode -Version Latest
 
 .PARAMETER  Filters
     All filters to check for applicability. Required properties: 'Type', 'Value', 'Property'
-    Supported types: 'wildcard', 'logicalOperation'
+    Supported types: 'wildcard', 'equalityOperator'
 #>
 function Get-ApplicableFilters {
     [CmdletBinding()]
@@ -27,8 +27,8 @@ function Get-ApplicableFilters {
                 $res['Strict'] = $true
             }
         } 
-        elseif ($filter.Type -eq 'logicalOperation') {
-            if (Test-LogicalFilter -Filter $filter) {
+        elseif ($filter.Type -eq 'equalityOperator') {
+            if (Test-EqualityFilter -Filter $filter) {
                 $res['Strict'] = $true
             }
         }
@@ -50,7 +50,7 @@ function Test-WildcardFilter {
     ($Filter) -and ($Filter.Value -is [System.String]) -and ($Filter.Value.Contains($Filter.Character))
 }
 
-function Test-LogicalFilter {
+function Test-EqualityFilter {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]

--- a/PSSwagger/Get-ApplicableFilters.ps1
+++ b/PSSwagger/Get-ApplicableFilters.ps1
@@ -31,6 +31,10 @@ function Get-ApplicableFilters {
             if (Test-EqualityFilter -Filter $filter) {
                 $res['Strict'] = $true
             }
+        } elseif ($filter.Type -eq 'powershellWildcard') {
+            if (Test-PSWildcardFilter -Filter $filter) {
+                $res['Strict'] = $true
+            }
         }
         if ($res['Strict'] -or $filter.Value) {
             $res
@@ -60,4 +64,15 @@ function Test-EqualityFilter {
 
     # Must be specified
     ($Filter -and $Filter.Value)
+}
+
+function Test-PSWildcardFilter {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]
+        $Filter
+    )
+
+    ($Filter) -and ($Filter.Value -is [System.String]) -and [WildcardPattern]::ContainsWildcardCharacters($Filter.Value)
 }

--- a/PSSwagger/Get-ApplicableFilters.ps1
+++ b/PSSwagger/Get-ApplicableFilters.ps1
@@ -1,0 +1,63 @@
+Microsoft.PowerShell.Core\Set-StrictMode -Version Latest
+
+<#
+.DESCRIPTION
+   Get all filters that are applicable based on their Value.
+
+.PARAMETER  Filters
+    All filters to check for applicability. Required properties: 'Type', 'Value', 'Property'
+    Supported types: 'wildcard', 'logicalOperation'
+#>
+function Get-ApplicableFilters {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject[]]
+        $Filters
+    )
+
+    $ErrorActionPreference = 'Stop'
+    foreach ($filter in $Filters) {
+        $res = @{
+            Filter = $filter
+            Strict = $false
+        }
+        if ($filter.Type -eq 'wildcard') {
+            if (Test-WildcardFilter -Filter $filter) {
+                $res['Strict'] = $true
+            }
+        } 
+        elseif ($filter.Type -eq 'logicalOperation') {
+            if (Test-LogicalFilter -Filter $filter) {
+                $res['Strict'] = $true
+            }
+        }
+        if ($res['Strict'] -or $filter.Value) {
+            $res
+        }
+    }
+}
+
+function Test-WildcardFilter {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]
+        $Filter
+    )
+
+    # Must contain wildcard character
+    ($Filter) -and ($Filter.Value -is [System.String]) -and ($Filter.Value.Contains($Filter.Character))
+}
+
+function Test-LogicalFilter {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]
+        $Filter
+    )
+
+    # Must be specified
+    ($Filter -and $Filter.Value)
+}

--- a/PSSwagger/PSSwagger.Resources.psd1
+++ b/PSSwagger/PSSwagger.Resources.psd1
@@ -91,5 +91,10 @@ ConvertFrom-StringData @'
     InvalidHeaderFilePath=The specified value '{0}' for Header parameter is should be a valid file path.
     HeaderContentTwoHyphenWarning=The specified Header content has '--', replacing '--' with '=='.
     PSScriptAnalyzerMissing=PSScriptAnalyzer specified as the formatter, but the module is not available on this machine. No formatting will be used. Run 'Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser' to install the module.
+    CouldntFindServerSideResultOperation=Couldn't find server-side result operation: {0}
+    CouldntFindServerSideResultParameterSet=Couldn't find server-side result parameter set: {0}
+    CouldntFindClientSideParameterSet=Couldn't find client-side parameter set: {0}
+    MissingRequiredFilterParameter=Required server-side parameter '{0}' is not required by the client-side, which will cause issues in client-side filtering. Can't include client-side filtering.
+    FailedToAddAutomaticFilter=Failed to add automatic client-side filter for candidate command '{0}': Mandatory List parameter '{1}' has no matching Get mandatory parameter. It will be impossible to guarantee execution of the List method before client-side filtering occurs.
 ###PSLOC
 '@

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -601,7 +601,6 @@ function New-PSSwaggerModule {
                         $listParameters = $null
                         $listOperationId = $null
                         $getOperationId = $null
-                        $nameParameterOriginalName = $null # This ideally matches the object property name
                         $nameParameterNormalName = $null # This is the one being switched out for -Name later
                         foreach ($parameterSetDetails in $entry.Value.ParameterSetDetails) {
                             if ($parameterSetDetails.OperationId.EndsWith("_Get") -and
@@ -613,12 +612,6 @@ function New-PSSwaggerModule {
                                         $getParameters += $parameterDetailEntry.Value
                                         if ($parameterDetailEntry.Value.ContainsKey('Alias')) {
                                             if ($parameterDetailEntry.Value.Alias -eq 'Name') {
-                                                if ($parameterDetailEntry.Value.ContainsKey('OriginalParameterName')) {
-                                                    $nameParameterOriginalName = $parameterDetailEntry.Value.OriginalParameterName
-                                                } else {
-                                                    $nameParameterOriginalName = $parameterDetailEntry.Value.Name
-                                                }
-
                                                 $nameParameterNormalName = $parameterDetailEntry.Value.Name
                                             }
                                         }
@@ -635,7 +628,7 @@ function New-PSSwaggerModule {
                             }
                         }
 
-                        if ($getParameters -and $listParameters -and $nameParameterOriginalName) {
+                        if ($getParameters -and $listParameters) {
                             $valid = $true
                             foreach ($parameterDetail in $listParameters) {
                                 if ($parameterDetail.Mandatory -eq '$true') {
@@ -668,8 +661,8 @@ function New-PSSwaggerModule {
                                     Add-Member -InputObject $nameWildcardFilter -Name 'Character' -Value $PowerShellCodeGen['DefaultWildcardChar'] -MemberType NoteProperty
                                     $filters = @($nameWildcardFilter)
                                     Add-Member -InputObject $clientSideFilter -Name 'Filters' -Value $filters -MemberType NoteProperty
-
-                                    Add-Member -InputObject $entry.Value['Metadata'] -Name 'ClientSideFilter' -Value $clientSideFilter -MemberType NoteProperty
+                                    $allClientSideFilters = @($clientSideFilter)
+                                    Add-Member -InputObject $entry.Value['Metadata'] -Name 'ClientSideFilter' -Value $allClientSideFilters -MemberType NoteProperty
                                 }
                             }
                         }

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -299,13 +299,14 @@ function New-PSSwaggerModule {
         $ev = $null
 
         $webRequestParams = @{
-            'Uri' = $SpecificationUri
+            'Uri'     = $SpecificationUri
             'OutFile' = $SpecificationPath
         }
 
-        if($Credential -ne $null) {
+        if ($Credential -ne $null) {
             $webRequestParams['Credential'] = $Credential
-        } elseif ($UseDefaultCredential) {
+        }
+        elseif ($UseDefaultCredential) {
             $webRequestParams['UseDefaultCredential'] = $true
         }
 
@@ -483,7 +484,8 @@ function New-PSSwaggerModule {
     if (-not $Formatter) {
         if ($PowerShellCodeGen['Formatter']) {
             $Formatter = $PowerShellCodeGen['Formatter']
-        } else {
+        }
+        else {
             $Formatter = 'None'
         }
     }
@@ -604,8 +606,8 @@ function New-PSSwaggerModule {
                         $nameParameterNormalName = $null # This is the one being switched out for -Name later
                         foreach ($parameterSetDetails in $entry.Value.ParameterSetDetails) {
                             if ($parameterSetDetails.OperationId.EndsWith("_Get") -and
-                            (-not ($parameterSetDetails.OperationId.StartsWith("InputObject_"))) -and
-                            (-not ($parameterSetDetails.OperationId.StartsWith("ResourceId_")))) {
+                                (-not ($parameterSetDetails.OperationId.StartsWith("InputObject_"))) -and
+                                (-not ($parameterSetDetails.OperationId.StartsWith("ResourceId_")))) {
                                 $getOperationId = $parameterSetDetails.OperationId
                                 foreach ($parametersDetail in $parameterSetDetails.ParameterDetails) {
                                     foreach ($parameterDetailEntry in $parametersDetail.GetEnumerator()) {
@@ -615,9 +617,14 @@ function New-PSSwaggerModule {
                                                 $nameParameterNormalName = $parameterDetailEntry.Value.Name
                                             }
                                         }
+                                        elseif ($parameterDetailEntry.Value.Name -eq 'Name') {
+                                            # We're currently assuming this is a resource name
+                                            $nameParameterNormalName = $parameterDetailEntry.Value.Name
+                                        }
                                     }
                                 }
-                            } elseif ($parameterSetDetails.OperationId.EndsWith("_List")) {
+                            }
+                            elseif ($parameterSetDetails.OperationId.EndsWith("_List")) {
                                 $listOperationId = $parameterSetDetails.OperationId
                                 $listParameters = @()
                                 foreach ($parametersDetail in $parameterSetDetails.ParameterDetails) {
@@ -662,7 +669,7 @@ function New-PSSwaggerModule {
                                     $filters = @($nameWildcardFilter)
                                     Add-Member -InputObject $clientSideFilter -Name 'Filters' -Value $filters -MemberType NoteProperty
                                     $allClientSideFilters = @($clientSideFilter)
-                                    Add-Member -InputObject $entry.Value['Metadata'] -Name 'ClientSideFilter' -Value $allClientSideFilters -MemberType NoteProperty
+                                    Add-Member -InputObject $entry.Value['Metadata'] -Name 'ClientSideFilters' -Value $allClientSideFilters -MemberType NoteProperty
                                 }
                             }
                         }
@@ -765,9 +772,9 @@ function New-PSSwaggerModule {
         -PSHeaderComment $PSHeaderComment
 
     $CopyFilesMap = [ordered]@{
-        'Get-TaskResult.ps1' = 'Get-TaskResult.ps1'
+        'Get-TaskResult.ps1'        = 'Get-TaskResult.ps1'
         'Get-ApplicableFilters.ps1' = 'Get-ApplicableFilters.ps1'
-        'Test-FilteredResult.ps1' = 'Test-FilteredResult.ps1'
+        'Test-FilteredResult.ps1'   = 'Test-FilteredResult.ps1'
     }
     if ($UseAzureCsharpGenerator) {
         $CopyFilesMap['New-ArmServiceClient.ps1'] = 'New-ServiceClient.ps1'
@@ -906,7 +913,8 @@ function ConvertTo-CsharpCode {
         $fs = [System.IO.File]::OpenRead($csc.Source)
         try {
             $null = $fs.Read($data, 0, 4096)
-        } finally {
+        }
+        finally {
             $fs.Dispose()
         }
 
@@ -919,7 +927,8 @@ function ConvertTo-CsharpCode {
         if ($magic -eq 0x20b) {
             # Skip to the end of IMAGE_OPTIONAL_HEADER64 to the first entry in the data directory array
             $p_dataDirectory0 = [System.BitConverter]::ToUInt32($data, [int]$p_ioh + 224)
-        } else {
+        }
+        else {
             # Same thing, but for IMAGE_OPTIONAL_HEADER32
             $p_dataDirectory0 = [System.BitConverter]::ToUInt32($data, [int]$p_ioh + 208)
         }

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -635,7 +635,7 @@ function New-PSSwaggerModule {
                                     $matchingGetParameter = $getParameters | Where-Object { ($_.Name -eq $parameterDetail.Name) -and ($_.Mandatory -eq '$true') }
                                     if (-not $matchingGetParameter) {
                                         $valid = $false
-                                        Write-Warning "Failed to add automatic client-side filter for candidate command '$($entry.Name)': Mandatory List parameter '$($parameterDetail.Name)' has no matching Get mandatory parameter. It will be impossible to guarantee execution of the List method before client-side filtering occurs."
+                                        Write-Warning -Message ($LocalizedData.FailedToAddAutomaticFilter -f $entry.Name)
                                     }
                                 }
                             }

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -455,6 +455,7 @@ function New-PSSwaggerModule {
         Header                = ''
         Formatter             = 'PSScriptAnalyzer'
         DefaultWildcardChar   = '%'
+        AzureDefaults         = $null
     }
 
     # Parse the JSON and populate the dictionary
@@ -587,7 +588,10 @@ function New-PSSwaggerModule {
         }
 
         # Add extra metadata based on service type
-        if (($PowerShellCodeGen['ServiceType'] -eq 'azure') -or ($PowerShellCodeGen['ServiceType'] -eq 'azure_stack')) {
+        if (($PowerShellCodeGen['ServiceType'] -eq 'azure') -or ($PowerShellCodeGen['ServiceType'] -eq 'azure_stack') -and
+        ($PowerShellCodeGen.ContainsKey('azureDefaults') -and $PowerShellCodeGen['azureDefaults'] -and
+         (-not (Get-Member -InputObject $PowerShellCodeGen['azureDefaults'] -Name 'clientSideFiltering')) -or
+         ($PowerShellCodeGen['azureDefaults'].ClientSideFiltering))) {
             foreach ($entry in $PathFunctionDetails.GetEnumerator()) {
                 $hyphenIndex = $entry.Name.IndexOf("-")
                 if ($hyphenIndex -gt -1) {
@@ -662,10 +666,9 @@ function New-PSSwaggerModule {
                                     Add-Member -InputObject $clientSideFilter -Name 'ClientSideParameterSet' -Value $getOperationId -MemberType NoteProperty
                                     # Create a wildcard filter for the Name parameter
                                     $nameWildcardFilter = New-Object -TypeName PSCustomObject
-                                    Add-Member -InputObject $nameWildcardFilter -Name 'Type' -Value 'wildcard' -MemberType NoteProperty
+                                    Add-Member -InputObject $nameWildcardFilter -Name 'Type' -Value 'powershellWildcard' -MemberType NoteProperty
                                     Add-Member -InputObject $nameWildcardFilter -Name 'Parameter' -Value $nameParameterNormalName -MemberType NoteProperty
                                     Add-Member -InputObject $nameWildcardFilter -Name 'Property' -Value 'Name' -MemberType NoteProperty
-                                    Add-Member -InputObject $nameWildcardFilter -Name 'Character' -Value $PowerShellCodeGen['DefaultWildcardChar'] -MemberType NoteProperty
                                     $filters = @($nameWildcardFilter)
                                     Add-Member -InputObject $clientSideFilter -Name 'Filters' -Value $filters -MemberType NoteProperty
                                     $allClientSideFilters = @($clientSideFilter)

--- a/PSSwagger/PSSwagger.psm1
+++ b/PSSwagger/PSSwagger.psm1
@@ -453,7 +453,7 @@ function New-PSSwaggerModule {
         NameSpacePrefix       = ''
         Header                = ''
         Formatter             = 'PSScriptAnalyzer'
-        DefaultWildcardChar   = '*'
+        DefaultWildcardChar   = '%'
     }
 
     # Parse the JSON and populate the dictionary
@@ -725,7 +725,8 @@ function New-PSSwaggerModule {
         -SwaggerDict $swaggerDict `
         -DefinitionFunctionsDetails $DefinitionFunctionsDetails `
         -PSHeaderComment $PSHeaderComment `
-        -Formatter $Formatter
+        -Formatter $Formatter `
+        -PowerShellCodeGen $PowerShellCodeGen
 
     $FunctionsToExport += New-SwaggerDefinitionCommand -DefinitionFunctionsDetails $DefinitionFunctionsDetails `
         -SwaggerMetaDict $swaggerMetaDict `

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -53,10 +53,10 @@ function Get-SwaggerSpecPathInfo
 
     $PSMetaPathJsonObject = $null
     if($PSMetaJsonObject) {
-        if(Get-Member -InputObject $PSMetaJsonObject.paths -Name $EndpointRelativePath) {
+        if((Get-Member -InputObject $PSMetaJsonObject -Name 'paths') -and (Get-Member -InputObject $PSMetaJsonObject.paths -Name $EndpointRelativePath)) {
             $PSMetaPathJsonObject = $PSMetaJsonObject.paths.$EndpointRelativePath
         }
-        elseif(Get-Member -InputObject $PSMetaJsonObject.'x-ms-paths' -Name $EndpointRelativePath) {
+        elseif((Get-Member -InputObject $PSMetaJsonObject -Name 'x-ms-paths') -and (Get-Member -InputObject $PSMetaJsonObject.'x-ms-paths' -Name $EndpointRelativePath)) {
             $PSMetaPathJsonObject = $PSMetaJsonObject.'x-ms-paths'.$EndpointRelativePath
         }
     }

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -661,7 +661,9 @@ function New-SwaggerPath {
                                 }
                             }
 
-                            $filterBlock = $executionContext.InvokeCommand.ExpandString($FilterBlockStr)
+                            if ($valid) {
+                                $filterBlock = $executionContext.InvokeCommand.ExpandString($FilterBlockStr)
+                            }
                         }
                     }
                 }

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -636,19 +636,18 @@ function New-SwaggerPath {
                     $serverSideFunctionDetails = $PathFunctionDetails[$clientSideFilter.ServerSideResultCommand]
                 }
                 if (-not $serverSideFunctionDetails) {
-                    # Warning: Couldn't find specified server-side command
-                    Write-Warning "Couldn't find server-side result operation: $($clientSideFilter.ServerSideResultCommand)"
+                    Write-Warning -Message ($LocalizedData.CouldntFindServerSideResultOperation -f $clientSideFilter.ServerSideResultCommand)
                 }
                 else {
                     $serverSideParameterSet = $serverSideFunctionDetails['ParameterSetDetails'] | Where-Object { $_.OperationId -eq $clientSideFilter.ServerSideResultParameterSet}
                     if (-not $serverSideParameterSet) {
                         # Warning: Couldn't find specified server-side parameter set
-                        Write-Warning "Couldn't find server-side result parameter set: $($clientSideFilter.ServerSideResultParameterSet)"
+                        Write-Warning -Message ($LocalizedData.CouldntFindServerSideResultParameterSet -f $clientSideFilter.ServerSideResultParameterSet)
                     }
                     else {
                         $clientSideParameterSet = $parameterSetDetails | Where-Object { $_.OperationId -eq $clientSideFilter.ClientSideParameterSet }
                         if (-not $clientSideParameterSet) {
-                            Write-Warning "Couldn't find client-side parameter set: $($clientSideFilter.ClientSideParameterSet)"
+                            Write-Warning -Message ($LocalizedData.CouldntFindClientSideParameterSet -f $clientSideFilter.ClientSideParameterSet)
                         }
                         else {
                             $valid = $true
@@ -667,8 +666,7 @@ function New-SwaggerPath {
                                         }
                                         if (-not $clientSideParameterSet) {
                                             # Warning: Missing client-side parameter
-                                            Write-Warning "Required server-side parameter '$($parameterDetailEntry.Value.Name)' is not required by the client-side, which will cause issues in client-side filtering. Can't include client-side filtering."
-                                            $valid = $false
+                                            Write-Warning -Message ($LocalizedData.MissingRequiredFilterParameter -f $parameterDetailEntry.Value.Name)
                                         }
                                         else {
                                             $matchingParameters += $parameterDetailEntry.Value.Name

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -617,7 +617,6 @@ function New-SwaggerPath {
                 $globalParametersStatic[$property.Name] = Get-ValueText($FunctionDetails['Metadata'].ClientParameters.$($property.Name))
             }
         }
-
         if (Get-Member -InputObject $FunctionDetails['Metadata'] -Name 'clientSideFilters') {
             foreach ($clientSideFilter in $FunctionDetails['Metadata'].ClientSideFilters) {
                 foreach ($filter in $clientSideFilter.Filters) {

--- a/PSSwagger/Paths.psm1
+++ b/PSSwagger/Paths.psm1
@@ -14,15 +14,14 @@ Import-Module (Join-Path -Path $PSScriptRoot -ChildPath SwaggerUtils.psm1) -Disa
 . "$PSScriptRoot\PSSwagger.Constants.ps1" -Force
 Microsoft.PowerShell.Utility\Import-LocalizedData  LocalizedData -filename PSSwagger.Resources.psd1
 
-function Get-SwaggerSpecPathInfo
-{
+function Get-SwaggerSpecPathInfo {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [PSObject]
         $JsonPathItemObject,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [PSCustomObject] 
         $PathFunctionDetails,
 
@@ -38,11 +37,11 @@ function Get-SwaggerSpecPathInfo
         [hashtable]
         $DefinitionFunctionsDetails,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $ParameterGroupCache,
 
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [PSCustomObject]
         $PSMetaJsonObject
     )
@@ -52,37 +51,36 @@ function Get-SwaggerSpecPathInfo
     $EndpointRelativePath = $JsonPathItemObject.Name
 
     $PSMetaPathJsonObject = $null
-    if($PSMetaJsonObject) {
-        if((Get-Member -InputObject $PSMetaJsonObject -Name 'paths') -and (Get-Member -InputObject $PSMetaJsonObject.paths -Name $EndpointRelativePath)) {
+    if ($PSMetaJsonObject) {
+        if ((Get-Member -InputObject $PSMetaJsonObject -Name 'paths') -and (Get-Member -InputObject $PSMetaJsonObject.paths -Name $EndpointRelativePath)) {
             $PSMetaPathJsonObject = $PSMetaJsonObject.paths.$EndpointRelativePath
         }
-        elseif((Get-Member -InputObject $PSMetaJsonObject -Name 'x-ms-paths') -and (Get-Member -InputObject $PSMetaJsonObject.'x-ms-paths' -Name $EndpointRelativePath)) {
+        elseif ((Get-Member -InputObject $PSMetaJsonObject -Name 'x-ms-paths') -and (Get-Member -InputObject $PSMetaJsonObject.'x-ms-paths' -Name $EndpointRelativePath)) {
             $PSMetaPathJsonObject = $PSMetaJsonObject.'x-ms-paths'.$EndpointRelativePath
         }
     }
 
     # First get path level common parameters, if any, which will be common to all operations in this swagger path.
     $PathCommonParameters = @{}
-    if(Get-Member -InputObject $JsonPathItemObject.value -Name 'Parameters')
-    {
+    if (Get-Member -InputObject $JsonPathItemObject.value -Name 'Parameters') {
         $PSMetaParametersJsonObject = $null
-        if($PSMetaPathJsonObject -and (Get-Member -InputObject $PSMetaPathJsonObject -Name 'parameters')) {
+        if ($PSMetaPathJsonObject -and (Get-Member -InputObject $PSMetaPathJsonObject -Name 'parameters')) {
             $PSMetaParametersJsonObject = $PSMetaPathJsonObject.'parameters'
         }
 
         $GetPathParamInfo_params = @{
-            JsonPathItemObject = $JsonPathItemObject.Value
-            SwaggerDict = $swaggerDict
+            JsonPathItemObject         = $JsonPathItemObject.Value
+            SwaggerDict                = $swaggerDict
             DefinitionFunctionsDetails = $DefinitionFunctionsDetails
-            ParameterGroupCache = $ParameterGroupCache
-            ParametersTable = $PathCommonParameters
+            ParameterGroupCache        = $ParameterGroupCache
+            ParametersTable            = $PathCommonParameters
             PSMetaParametersJsonObject = $PSMetaParametersJsonObject
         }
         Get-PathParamInfo @GetPathParamInfo_params
     }
 
     $ResourceIdAndInputObjectDetails = $null
-    if($UseAzureCsharpGenerator) {
+    if ($UseAzureCsharpGenerator) {
         $GetResourceIdParameters_params = @{
             JsonPathItemObject = $JsonPathItemObject
             ResourceId         = $EndpointRelativePath
@@ -114,50 +112,58 @@ function Get-SwaggerSpecPathInfo
             if ((Get-Member -InputObject $_.Value.'x-ms-pageable' -Name 'nextLinkName')) {
                 if ($_.Value.'x-ms-pageable'.'nextLinkName') {
                     $x_ms_pageableObject['nextLinkName'] = $_.Value.'x-ms-pageable'.'nextLinkName'
-                } else {
+                }
+                else {
                     $x_ms_pageableObject = $null
                 }
             }
         }
 
-        if(Get-Member -InputObject $_.Value -Name 'security')
-        {
+        if (Get-Member -InputObject $_.Value -Name 'security') {
             $operationSecurityObject = $_.Value.'security'
-        } elseif ($swaggerDict.ContainsKey('Security')) {
+        }
+        elseif ($swaggerDict.ContainsKey('Security')) {
             $operationSecurityObject = $swaggerDict['Security']
-        } else {
+        }
+        else {
             $operationSecurityObject = $null
         }
 
         $cmdletInfoOverrides = @()
         $PSMetaOperationJsonObject = $null
-        if($PSMetaPathJsonObject -and
-           (Get-Member -InputObject $PSMetaPathJsonObject -Name $operationType)) {
+        if ($PSMetaPathJsonObject -and
+            (Get-Member -InputObject $PSMetaPathJsonObject -Name $operationType)) {
             $PSMetaOperationJsonObject = $PSMetaPathJsonObject.$operationType
         }
 
-        if(Get-Member -InputObject $_.Value -Name 'OperationId')
-        {
+        if (Get-Member -InputObject $_.Value -Name 'OperationId') {
             $operationId = $_.Value.operationId
             Write-Verbose -Message ($LocalizedData.GettingSwaggerSpecPathInfo -f $operationId)
 
             $defaultCommandNames = Get-PathCommandName -OperationId $operationId
-            if($PSMetaOperationJsonObject -and
-            (Get-Member -InputObject $PSMetaOperationJsonObject -Name 'x-ps-cmdlet-infos')) {
+            if ($PSMetaOperationJsonObject -and
+                (Get-Member -InputObject $PSMetaOperationJsonObject -Name 'x-ps-cmdlet-infos')) {
                 $PSMetaOperationJsonObject.'x-ps-cmdlet-infos' | ForEach-Object {
+                    $metadataName = $null
+                    if (Get-Member -InputObject $_ -Name 'name') {
+                        $metadataName = $_.name
+                    }
+
                     $cmdletInfoOverride = @{
-                        Name = $_.name
+                        Name     = $metadataName
                         Metadata = $_
                     }
+
                     # If no name override is specified, apply all these overrides to each default command name
-                    if (-not $_.name) {
+                    if (-not $metadataName) {
                         foreach ($defaultCommandName in $defaultCommandNames) {
                             $cmdletInfoOverrides += @{
-                                Name = $defaultCommandName.name
+                                Name     = $defaultCommandName.name
                                 Metadata = $cmdletInfoOverride.Metadata
                             }
                         }
-                    } else {
+                    }
+                    else {
                         $cmdletInfoOverrides += $cmdletInfoOverride
                     }
                 }
@@ -175,23 +181,24 @@ function Get-SwaggerSpecPathInfo
                     if (-not (Get-Member -InputObject $cmdletMetadata -Name 'name')) {
                         foreach ($defaultCommandName in $defaultCommandNames) {
                             $cmdletInfoOverrides += @{
-                                Name = $defaultCommandName.name
+                                Name     = $defaultCommandName.name
                                 Metadata = $cmdletInfoOverride.Metadata
                             }
                         }
-                    } else {
+                    }
+                    else {
                         $cmdletInfoOverrides += $cmdletInfoOverride
                     }
                 }
             }
 
             $FunctionDescription = ""
-            if((Get-Member -InputObject $_.value -Name 'description') -and $_.value.description) {
+            if ((Get-Member -InputObject $_.value -Name 'description') -and $_.value.description) {
                 $FunctionDescription = $_.value.description 
             }
 
             $FunctionSynopsis = ''
-            if((Get-Member -InputObject $_.value -Name 'Summary') -and $_.value.Summary) {
+            if ((Get-Member -InputObject $_.value -Name 'Summary') -and $_.value.Summary) {
                 $FunctionSynopsis = $_.value.Summary 
             }
             
@@ -200,44 +207,43 @@ function Get-SwaggerSpecPathInfo
             $PathCommonParameters.GetEnumerator() | ForEach-Object {
                 # Cloning the common parameters object so that some values can be updated.
                 $PathCommonParamDetails = $_.Value.Clone()
-                if($PathCommonParamDetails.ContainsKey('OriginalParameterName') -and $PathCommonParamDetails.OriginalParameterName)
-                {
+                if ($PathCommonParamDetails.ContainsKey('OriginalParameterName') -and $PathCommonParamDetails.OriginalParameterName) {
                     $PathCommonParamDetails['OriginalParameterName'] = ''
                 }
                 $ParametersTable[$_.Key] = $PathCommonParamDetails
             }
 
             $PSMetaParametersJsonObject = $null
-            if($PSMetaOperationJsonObject -and (Get-Member -InputObject $PSMetaOperationJsonObject -Name 'parameters')) {
+            if ($PSMetaOperationJsonObject -and (Get-Member -InputObject $PSMetaOperationJsonObject -Name 'parameters')) {
                 $PSMetaParametersJsonObject = $PSMetaOperationJsonObject.'parameters'
             }
 
             $GetPathParamInfo_params2 = @{
-                JsonPathItemObject = $_.value
-                SwaggerDict = $swaggerDict
+                JsonPathItemObject         = $_.value
+                SwaggerDict                = $swaggerDict
                 DefinitionFunctionsDetails = $DefinitionFunctionsDetails
-                ParameterGroupCache = $ParameterGroupCache
-                ParametersTable = $ParametersTable
+                ParameterGroupCache        = $ParameterGroupCache
+                ParametersTable            = $ParametersTable
                 PSMetaParametersJsonObject = $PSMetaParametersJsonObject
             }
             Get-PathParamInfo @GetPathParamInfo_params2
 
             $responses = ""
-            if((Get-Member -InputObject $_.value -Name 'responses') -and $_.value.responses) {
+            if ((Get-Member -InputObject $_.value -Name 'responses') -and $_.value.responses) {
                 $responses = $_.value.responses 
             }
 
-            if($cmdletInfoOverrides)
-            {
+            if ($cmdletInfoOverrides) {
                 $commandNames = $cmdletInfoOverrides
-            } else {
+            }
+            else {
                 $commandNames = Get-PathCommandName -OperationId $operationId
             }
             
             # Priority of a parameterset will be used to determine the default parameterset of a cmdlet.
             $Priority = 0
             $ParametersCount = Get-HashtableKeyCount -Hashtable $ParametersTable
-            if($ParametersCount) {
+            if ($ParametersCount) {
                 # Priority for parameter sets with mandatory parameters starts at 100
                 $Priority = 100
 
@@ -250,21 +256,21 @@ function Get-SwaggerSpecPathInfo
                 }
                     
                 $ParametersTable.GetEnumerator() | ForEach-Object {
-                    if($_.Value.ContainsKey('Mandatory') -and $_.Value.Mandatory -eq '$true') {
+                    if ($_.Value.ContainsKey('Mandatory') -and $_.Value.Mandatory -eq '$true') {
                         $Priority++
                     }
 
                     # Add alias for the resource name parameter.
-                    if($ResourceIdAndInputObjectDetails -and
-                       -not $NameParameterDetails -and
-                       ($_.Value.Name -ne 'Name') -and
-                       ($_.Value.Name -eq $ResourceIdAndInputObjectDetails.ResourceName)) {
+                    if ($ResourceIdAndInputObjectDetails -and
+                        -not $NameParameterDetails -and
+                        ($_.Value.Name -ne 'Name') -and
+                        ($_.Value.Name -eq $ResourceIdAndInputObjectDetails.ResourceName)) {
                         $_.Value['Alias'] = 'Name'
                     }
                 }
 
                 # If there are no mandatory parameters, use the parameter count as the priority.                
-                if($Priority -eq 100) {
+                if ($Priority -eq 100) {
                     $Priority = $ParametersCount
                 }
             }
@@ -289,21 +295,21 @@ function Get-SwaggerSpecPathInfo
             }
 
             # There's probably a better way to do this...
-            $opIdValues = $operationId -split "_",2
-            if(-not $opIdValues -or ($opIdValues.Count -ne 2)) {
+            $opIdValues = $operationId -split "_", 2
+            if (-not $opIdValues -or ($opIdValues.Count -ne 2)) {
                 $approximateVerb = $operationId
-            } else {
+            }
+            else {
                 $approximateVerb = $opIdValues[1]
                 if ((-not $UseAzureCsharpGenerator) -and 
-                    (Test-OperationNameInDefinitionList -Name $opIdValues[0] -SwaggerDict $swaggerDict))
-                { 
+                    (Test-OperationNameInDefinitionList -Name $opIdValues[0] -SwaggerDict $swaggerDict)) { 
                     $ParameterSetDetail['UseOperationsSuffix'] = $true
                 }
             }
             
             $InputObjectParameterSetDetail = $null
             $ResourceIdParameterSetDetail = $null
-            if($ResourceIdAndInputObjectDetails) {
+            if ($ResourceIdAndInputObjectDetails) {
                 # InputObject parameterset
                 $InputObjectParameterDetails = @{
                     Name                  = 'InputObject'
@@ -321,7 +327,7 @@ function Get-SwaggerSpecPathInfo
                 $ClonedParameterSetDetail = $ParameterSetDetail.Clone()
                 $ClonedParameterSetDetail.ParameterDetails.GetEnumerator() | ForEach-Object {
                     $paramDetails = $_.Value
-                    if($ResourceIdAndInputObjectDetails.ResourceIdParameters -notcontains $paramDetails.Name) {
+                    if ($ResourceIdAndInputObjectDetails.ResourceIdParameters -notcontains $paramDetails.Name) {
                         $InputObjectParamSetParameterDetails[$index++] = $paramDetails
                     }
                 }
@@ -347,7 +353,7 @@ function Get-SwaggerSpecPathInfo
                 $ClonedParameterSetDetail = $ParameterSetDetail.Clone()
                 $ClonedParameterSetDetail.ParameterDetails.GetEnumerator() | ForEach-Object {
                     $paramDetails = $_.Value
-                    if($ResourceIdAndInputObjectDetails.ResourceIdParameters -notcontains $paramDetails.Name) {
+                    if ($ResourceIdAndInputObjectDetails.ResourceIdParameters -notcontains $paramDetails.Name) {
                         $ResourceIdParamSetParameterDetails[$index++] = $paramDetails
                     }
                 }
@@ -367,7 +373,8 @@ function Get-SwaggerSpecPathInfo
                 $FunctionDetails = @{}
                 if ($PathFunctionDetails.ContainsKey($_.name)) {
                     $FunctionDetails = $PathFunctionDetails[$_.name]
-                } else {
+                }
+                else {
                     $FunctionDetails['CommandName'] = $_.name
                     $FunctionDetails['x-ms-long-running-operation'] = $longRunningOperation
                 }
@@ -386,10 +393,10 @@ function Get-SwaggerSpecPathInfo
                 } 
 
                 $ParameterSetDetails += $ParameterSetDetail
-                if($InputObjectParameterSetDetail) {
+                if ($InputObjectParameterSetDetail) {
                     $ParameterSetDetails += $InputObjectParameterSetDetail
                 }
-                if($ResourceIdParameterSetDetail) {
+                if ($ResourceIdParameterSetDetail) {
                     $ParameterSetDetails += $ResourceIdParameterSetDetail
                 }
     
@@ -397,20 +404,18 @@ function Get-SwaggerSpecPathInfo
                 $PathFunctionDetails[$_.name] = $FunctionDetails
             }
         }
-        elseif(-not ((Get-Member -InputObject $_ -Name 'Name') -and ($_.Name -eq 'Parameters')))
-        {
+        elseif (-not ((Get-Member -InputObject $_ -Name 'Name') -and ($_.Name -eq 'Parameters'))) {
             $Message = $LocalizedData.UnsupportedSwaggerProperties -f ('JsonPathItemObject', $($_.Value | Out-String))
             Write-Warning -Message $Message
         }
     }
 }
 
-function New-SwaggerSpecPathCommand
-{
+function New-SwaggerSpecPathCommand {
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $PathFunctionDetails,
 
@@ -422,16 +427,16 @@ function New-SwaggerSpecPathCommand
         [hashtable]
         $SwaggerDict,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $DefinitionFunctionsDetails,
 
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [AllowEmptyString()]
         [string]
         $PSHeaderComment,
 
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [ValidateSet('None', 'PSScriptAnalyzer')]
         [string]
         $Formatter = 'None'
@@ -443,12 +448,12 @@ function New-SwaggerSpecPathCommand
     Preprocess-PagingOperations -PathFunctionDetails $PathFunctionDetails
     $PathFunctionDetails.GetEnumerator() | ForEach-Object {
         $FunctionsToExport += New-SwaggerPath -FunctionDetails $_.Value `
-                                              -SwaggerMetaDict $SwaggerMetaDict `
-                                              -SwaggerDict $SwaggerDict `
-                                              -PathFunctionDetails $PathFunctionDetails `
-                                              -DefinitionFunctionsDetails $DefinitionFunctionsDetails `
-                                              -PSHeaderComment $PSHeaderComment `
-                                              -Formatter $Formatter
+            -SwaggerMetaDict $SwaggerMetaDict `
+            -SwaggerDict $SwaggerDict `
+            -PathFunctionDetails $PathFunctionDetails `
+            -DefinitionFunctionsDetails $DefinitionFunctionsDetails `
+            -PSHeaderComment $PSHeaderComment `
+            -Formatter $Formatter
     }
 
     return $FunctionsToExport
@@ -460,7 +465,7 @@ These are single page operations and should never be unrolled (in the case of -n
 function Preprocess-PagingOperations {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $PathFunctionDetails
     )
@@ -482,23 +487,23 @@ function Add-UniqueParameter {
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $ParameterDetails,
         
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $CandidateParameterDetails,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]
         $ParameterSetName,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $ParametersToAdd,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $ParameterHitCount
     )
@@ -506,7 +511,7 @@ function Add-UniqueParameter {
     Get-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
     $parameterName = $CandidateParameterDetails.Name
-    if($parameterDetails.IsParameter) {
+    if ($parameterDetails.IsParameter) {
         if (-not $parameterHitCount.ContainsKey($parameterName)) {
             $parameterHitCount[$parameterName] = 0
         }
@@ -515,27 +520,28 @@ function Add-UniqueParameter {
         if (-not ($parametersToAdd.ContainsKey($parameterName))) {
             $parametersToAdd[$parameterName] = @{
                 # We can grab details like Type, Name, ValidateSet from any of the parameter definitions
-                Details = $CandidateParameterDetails
+                Details          = $CandidateParameterDetails
                 ParameterSetInfo = @{$ParameterSetName = @{
-                    Name = $ParameterSetName
-                    Mandatory = $CandidateParameterDetails.Mandatory
-                }}
+                        Name      = $ParameterSetName
+                        Mandatory = $CandidateParameterDetails.Mandatory
+                    }
+                }
             }
-        } else {
+        }
+        else {
             $parametersToAdd[$parameterName].ParameterSetInfo[$ParameterSetName] = @{
-                                                                        Name = $ParameterSetName
-                                                                        Mandatory = $CandidateParameterDetails.Mandatory
-                                                                    }
+                Name      = $ParameterSetName
+                Mandatory = $CandidateParameterDetails.Mandatory
+            }
         }
     }
 }
 
-function New-SwaggerPath
-{
+function New-SwaggerPath {
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $FunctionDetails,
 
@@ -551,16 +557,16 @@ function New-SwaggerPath
         [hashtable]
         $PathFunctionDetails,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $DefinitionFunctionsDetails,
         
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [AllowEmptyString()]
         [string]
         $PSHeaderComment,
 
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [ValidateSet('None', 'PSScriptAnalyzer')]
         [string]
         $Formatter = 'None'
@@ -588,6 +594,7 @@ function New-SwaggerPath
     $globalParameters = @()
     $x_ms_pageableObject = $null
     $globalParametersStatic = @{}
+    $filterBlock = $null
     # Process global metadata for commands
     if ($SwaggerDict.ContainsKey('CommandDefaults')) {
         foreach ($entry in $SwaggerDict['CommandDefaults'].GetEnumerator()) {
@@ -601,6 +608,88 @@ function New-SwaggerPath
                 $globalParametersStatic[$property.Name] = Get-ValueText($FunctionDetails['Metadata'].ClientParameters.$($property.Name))
             }
         }
+
+        if (Get-Member -InputObject $FunctionDetails['Metadata'] -Name 'clientSideFilter') {
+            $clientSideFilter = $FunctionDetails['Metadata'].ClientSideFilter
+            $matchingParameters = @()
+            $serverSideFunctionDetails = $null
+            if ($clientSideFilter.ServerSideResultCommand -eq '.') {
+                $serverSideFunctionDetails = $FunctionDetails
+            }
+            else {
+                $serverSideFunctionDetails = $PathFunctionDetails[$clientSideFilter.ServerSideResultCommand]
+            }
+            if (-not $serverSideFunctionDetails) {
+                # Warning: Couldn't find specified server-side command
+                Write-Warning "Couldn't find server-side result operation: $($clientSideFilter.ServerSideResultCommand)"
+            }
+            else {
+                $serverSideParameterSet = $serverSideFunctionDetails['ParameterSetDetails'] | Where-Object { $_.OperationId -eq $clientSideFilter.ServerSideResultParameterSet}
+                if (-not $serverSideParameterSet) {
+                    # Warning: Couldn't find specified server-side parameter set
+                    Write-Warning "Couldn't find server-side result parameter set: $($clientSideFilter.ServerSideResultParameterSet)"
+                }
+                else {
+                    $clientSideParameterSet = $parameterSetDetails | Where-Object { $_.OperationId -eq $clientSideFilter.ClientSideParameterSet }
+                    if (-not $clientSideParameterSet) {
+                        Write-Warning "Couldn't find client-side parameter set: $($clientSideFilter.ClientSideParameterSet)"
+                    }
+                    else {
+                        $valid = $true
+                        foreach ($parametersDetail in $serverSideParameterSet.ParameterDetails) {
+                            foreach ($parameterDetailEntry in $parametersDetail.GetEnumerator()) {
+                                if ($parameterDetailEntry.Value.Mandatory -eq '$true' -and
+                                ((-not $parameterDetailEntry.Value.ContainsKey('ReadOnlyGlobalParameter')) -or $parameterDetailEntry.Value.ReadOnlyGlobalParameter) -and
+                                ((-not $parameterDetailEntry.Value.ContainsKey('ConstantValue')) -or $parameterDetailEntry.Value.ConstantValue)) {
+                                    $clientSideParameter = $null
+                                    foreach ($pd in $clientSideParameterSet.ParameterDetails.GetEnumerator()) {
+                                        foreach ($entry in $pd.GetEnumerator()) {
+                                            if (($entry.Value.Mandatory -eq '$true') -and ($entry.Value.Name -eq $parameterDetailEntry.Value.Name)) {
+                                                $clientSideParameter = $entry
+                                            }
+                                        }
+                                    }
+                                    if (-not $clientSideParameterSet) {
+                                        # Warning: Missing client-side parameter
+                                        Write-Warning "Required server-side parameter '$($parameterDetailEntry.Value.Name)' is not required by the client-side, which will cause issues in client-side filtering. Can't include client-side filtering."
+                                        $valid = $false
+                                    }
+                                    else {
+                                        $matchingParameters += $parameterDetailEntry.Value.Name
+                                    }
+                                }
+                            }
+                        }
+
+                        $filterBlock = $executionContext.InvokeCommand.ExpandString($FilterBlockStr)
+                    }
+                }
+            }
+
+            # If this is filled out, means that all the inputs were validated (except maybe the filter details)
+            if ($filterBlock) {
+                foreach ($filter in $clientSideFilter.Filters) {
+                    if (Get-Member -InputObject $filter -Name 'appendParameterInfo') {
+                        $parameterDetails = @{
+                            'Name'        = [Char]::ToUpper($filter.Parameter[0]) + $filter.Parameter.Substring(1)
+                            'Mandatory'   = '$false'
+                            'Type'        = $filter.AppendParameterInfo.Type
+                            'ValidateSet' = ''
+                            'Description' = 'Filter parameter'
+                            'IsParameter' = $true
+                        }
+                        $AddUniqueParameter_params = @{
+                            ParameterDetails          = $parameterDetails
+                            CandidateParameterDetails = $parameterDetails
+                            ParameterSetName          = $clientSideFilter.ClientSideParameterSet
+                            ParametersToAdd           = $parametersToAdd
+                            ParameterHitCount         = $parameterHitCount
+                        }
+                        Add-UniqueParameter @AddUniqueParameter_params
+                    }
+                }
+            }
+        }
     }
     foreach ($parameterSetDetail in $parameterSetDetails) {
         if ($parameterSetDetail.ContainsKey('x-ms-pageable') -and $parameterSetDetail.'x-ms-pageable' -and (-not $isNextPageOperation)) {
@@ -610,10 +699,11 @@ function New-SwaggerPath
                 ($x_ms_pageableObject.ReturnType -ne $parameterSetDetail.ReturnType)) {
                 Write-Warning -Message ($LocalizedData.MultiplePageReturnTypes -f ($commandName))
                 $x_ms_pageableObject.ReturnType = 'NONE'
-            } elseif (-not $x_ms_pageableObject) {
+            }
+            elseif (-not $x_ms_pageableObject) {
                 $x_ms_pageableObject = $parameterSetDetail.'x-ms-pageable'
                 $x_ms_pageableObject['ReturnType'] = $parameterSetDetail.ReturnType
-                if($parameterSetDetail.ContainsKey('PSCmdletOutputItemType')) {
+                if ($parameterSetDetail.ContainsKey('PSCmdletOutputItemType')) {
                     $x_ms_pageableObject['PSCmdletOutputItemType'] = $parameterSetDetail.PSCmdletOutputItemType
                 }
                 if ($x_ms_pageableObject.Containskey('operationName')) {
@@ -644,7 +734,8 @@ function New-SwaggerPath
                         if ($matchingCurrentParameter) {
                             $cmdletArgsPageParameterSet += "-$($pagingParameter.Name) `$$($pagingParameter.Name) "
                             $cmdletArgsNoPaging += "-$($pagingParameter.Name) `$$($pagingParameter.Name) "
-                        } else {
+                        }
+                        else {
                             $unmatchedParameters += $pagingParameter
                             $cmdletArgsPageParameterSet += "-$($pagingParameter.Name) `$Page.NextPageLink "
                             $cmdletArgsNoPaging += "-$($pagingParameter.Name) `$result.NextPageLink "
@@ -658,7 +749,8 @@ function New-SwaggerPath
                     $x_ms_pageableObject['Cmdlet'] = $pagingFunctionDetails.Value.CommandName
                     $x_ms_pageableObject['CmdletArgsPage'] = $cmdletArgsPageParameterSet.Trim()
                     $x_ms_pageableObject['CmdletArgsPaging'] = $cmdletArgsNoPaging.Trim()
-                } else {
+                }
+                else {
                     $x_ms_pageableObject['Operations'] = $parameterSetDetail.Operations
                     $x_ms_pageableObject['MethodName'] = "$($parameterSetDetail.MethodName.Substring(0, $parameterSetDetail.MethodName.IndexOf('WithHttpMessagesAsync')))NextWithHttpMessagesAsync"
                 }
@@ -672,9 +764,11 @@ function New-SwaggerPath
                 # Check if a global has been added already
                 if ($parametersToAdd.ContainsKey("$($parameterDetails.Name)Global")) {
                     $parameterRequiresAdding = $false
-                } elseif ($parameterDetails.ContainsKey('ReadOnlyGlobalParameter') -and $parameterDetails.ReadOnlyGlobalParameter) {
+                }
+                elseif ($parameterDetails.ContainsKey('ReadOnlyGlobalParameter') -and $parameterDetails.ReadOnlyGlobalParameter) {
                     $parameterRequiresAdding = $false
-                } else {
+                }
+                else {
                     $globalParameterName = $parameterDetails.Name
                     $globalParameterValue = "```$$($parameterDetails.Name)"
                     if ($parameterDetails.ContainsKey('ConstantValue') -and $parameterDetails.ConstantValue) {
@@ -689,9 +783,9 @@ function New-SwaggerPath
 
             if ($parameterRequiresAdding) {
                 $AddUniqueParameter_params = @{
-                    ParameterDetails = $parameterDetails
-                    ParameterSetName = $parameterSetDetail.ParameterSetName
-                    ParametersToAdd = $parametersToAdd
+                    ParameterDetails  = $parameterDetails
+                    ParameterSetName  = $parameterSetDetail.ParameterSetName
+                    ParametersToAdd   = $parametersToAdd
                     ParameterHitCount = $parameterHitCount
                 }
 
@@ -700,9 +794,10 @@ function New-SwaggerPath
                         $AddUniqueParameter_params['CandidateParameterDetails'] = $parameterDetailEntry.Value
                         Add-UniqueParameter @AddUniqueParameter_params
                     }
-                } elseif($parameterDetails.ContainsKey('FlattenOnPSCmdlet') -and $parameterDetails.FlattenOnPSCmdlet) {
+                }
+                elseif ($parameterDetails.ContainsKey('FlattenOnPSCmdlet') -and $parameterDetails.FlattenOnPSCmdlet) {
                     $DefinitionName = ($parameterDetails.Type -split '[.]')[-1]
-                    if($DefinitionFunctionsDetails.ContainsKey($DefinitionName)) {
+                    if ($DefinitionFunctionsDetails.ContainsKey($DefinitionName)) {
                         $DefinitionDetails = $DefinitionFunctionsDetails[$DefinitionName]
                         $flattenedParametersOnPSCmdlet[$parameterDetails.Name] = $DefinitionDetails
                         $DefinitionDetails.ParametersTable.GetEnumerator() | ForEach-Object {
@@ -710,14 +805,16 @@ function New-SwaggerPath
                             Add-UniqueParameter @AddUniqueParameter_params
                         }
                     }
-                    else{
-                        Throw ($LocalizedData.InvalidPSMetaFlattenParameter -f ($parameterDetails.Name,$parameterDetails.Type))
+                    else {
+                        Throw ($LocalizedData.InvalidPSMetaFlattenParameter -f ($parameterDetails.Name, $parameterDetails.Type))
                     }
-                } else {
+                }
+                else {
                     $AddUniqueParameter_params['CandidateParameterDetails'] = $parameterDetails
                     Add-UniqueParameter @AddUniqueParameter_params
                 }
-            } else {
+            }
+            else {
                 # This magic string is here to distinguish local vs global parameters with the same name, e.g. in the Azure Resources API
                 $parametersToAdd["$($parameterDetails.Name)Global"] = $null
             }
@@ -737,7 +834,7 @@ function New-SwaggerPath
     if ($x_ms_pageableObject) {
         if ($x_ms_pageableObject.ReturnType -ne 'NONE') {
             $pageType = $x_ms_pageableObject.ReturnType
-            if($x_ms_pageableObject.ContainsKey('PSCmdletOutputItemType')) {
+            if ($x_ms_pageableObject.ContainsKey('PSCmdletOutputItemType')) {
                 $PSCmdletOutputItemType = $x_ms_pageableObject.PSCmdletOutputItemType                
             }
         }
@@ -745,7 +842,8 @@ function New-SwaggerPath
         if ($x_ms_pageableObject.ContainsKey('Operations')) {
             $pagingOperations = $x_ms_pageableObject.Operations
             $pagingOperationName = $x_ms_pageableObject.MethodName
-        } else {
+        }
+        else {
             $Cmdlet = $x_ms_pageableObject.Cmdlet
             $CmdletArgs = $x_ms_pageableObject.CmdletArgsPaging
         }
@@ -755,34 +853,34 @@ function New-SwaggerPath
         }
 
         $topParameterToAdd = @{
-            Details = @{
-                Name = 'Top'
-                Type = 'int'
-                Mandatory = '$false'
-                Description = 'Return the top N items as specified by the parameter value. Applies after the -Skip parameter.'
-                IsParameter = $true
-                ValidateSet = $null
+            Details          = @{
+                Name         = 'Top'
+                Type         = 'int'
+                Mandatory    = '$false'
+                Description  = 'Return the top N items as specified by the parameter value. Applies after the -Skip parameter.'
+                IsParameter  = $true
+                ValidateSet  = $null
                 ExtendedData = @{
-                    Type = 'int'
+                    Type            = 'int'
                     HasDefaultValue = $true
-                    DefaultValue = -1
+                    DefaultValue    = -1
                 }
             }
             ParameterSetInfo = @{}
         }
 
         $skipParameterToAdd = @{
-            Details = @{
-                Name = 'Skip'
-                Type = 'int'
-                Mandatory = '$false'
-                Description = 'Skip the first N items as specified by the parameter value.'
-                IsParameter = $true
-                ValidateSet = $null
+            Details          = @{
+                Name         = 'Skip'
+                Type         = 'int'
+                Mandatory    = '$false'
+                Description  = 'Skip the first N items as specified by the parameter value.'
+                IsParameter  = $true
+                ValidateSet  = $null
                 ExtendedData = @{
-                    Type = 'int'
+                    Type            = 'int'
                     HasDefaultValue = $true
-                    DefaultValue = -1
+                    DefaultValue    = -1
                 }
             }
             ParameterSetInfo = @{}
@@ -836,34 +934,36 @@ function New-SwaggerPath
                 if ($type -eq 'basic') {
                     # For Basic Authentication, allow the user to pass in a PSCredential object.
                     $credentialParameter = @{
-                        Details = @{
-                            Name = 'Credential'
-                            Type = 'PSCredential'
-                            Mandatory = '$true'
-                            Description = 'User credentials.'
-                            IsParameter = $true
-                            ValidateSet = $null
+                        Details          = @{
+                            Name         = 'Credential'
+                            Type         = 'PSCredential'
+                            Mandatory    = '$true'
+                            Description  = 'User credentials.'
+                            IsParameter  = $true
+                            ValidateSet  = $null
                             ExtendedData = @{
-                                Type = 'PSCredential'
+                                Type            = 'PSCredential'
                                 HasDefaultValue = $false
                             }
                         }
                         ParameterSetInfo = @{}
                     }
                     $securityParametersToAdd += @{
-                        Parameter = $credentialParameter
+                        Parameter                           = $credentialParameter
                         IsConflictingWithOperationParameter = $false
                     }
                     # If the service is specified to not issue authentication challenges, we can't rely on HttpClientHandler
                     if ($PowerShellCodeGen['NoAuthChallenge'] -and ($PowerShellCodeGen['NoAuthChallenge'] -eq $true)) {
                         $AuthenticationCommand = 'param([pscredential]$Credential) Get-AutoRestCredential -Credential $Credential'
                         $AuthenticationCommandArgumentName = 'Credential'
-                    } else {
+                    }
+                    else {
                         # Use an empty service client credentials object because we're using HttpClientHandler instead
                         $AuthenticationCommand = 'Get-AutoRestCredential'
                         $AddHttpClientHandler = $true
                     }
-                } elseif ($type -eq 'apiKey') {
+                }
+                elseif ($type -eq 'apiKey') {
                     if (-not (Get-Member -InputObject $securityDefinition -Name 'name')) {
                         throw ($LocalizedData.SecurityDefinitionMissingProperty -f ($firstSecurityObject.Name, 'name'))
                     }
@@ -877,27 +977,28 @@ function New-SwaggerPath
                     # For API key authentication, the user should supply the API key, but the in location and the name are generated from the spec
                     # In addition, we'd be unable to authenticate without the API key, so make it mandatory
                     $credentialParameter = @{
-                        Details = @{
-                            Name = 'APIKey'
-                            Type = 'string'
-                            Mandatory = '$true'
-                            Description = 'API key given by service owner.'
-                            IsParameter = $true
-                            ValidateSet = $null
+                        Details          = @{
+                            Name         = 'APIKey'
+                            Type         = 'string'
+                            Mandatory    = '$true'
+                            Description  = 'API key given by service owner.'
+                            IsParameter  = $true
+                            ValidateSet  = $null
                             ExtendedData = @{
-                                Type = 'string'
+                                Type            = 'string'
                                 HasDefaultValue = $false
                             }
                         }
                         ParameterSetInfo = @{}
                     }
                     $securityParametersToAdd += @{
-                        Parameter = $credentialParameter
+                        Parameter                           = $credentialParameter
                         IsConflictingWithOperationParameter = $false
                     }
                     $AuthenticationCommand = "param([string]`$APIKey) Get-AutoRestCredential -APIKey `$APIKey -Location '$in' -Name '$name'"
                     $AuthenticationCommandArgumentName = 'APIKey'
-                } else {
+                }
+                else {
                     Write-Warning -Message ($LocalizedData.UnsupportedAuthenticationType -f ($type))
                 }
             }
@@ -914,14 +1015,14 @@ function New-SwaggerPath
         # Add parameter sets to paging parameter sets
         if ($topParameterToAdd -and $parameterSetDetail.ContainsKey('x-ms-pageable') -and $parameterSetDetail.'x-ms-pageable' -and (-not $isNextPageOperation)) {
             $topParameterToAdd.ParameterSetInfo[$parameterSetDetail.ParameterSetName] = @{
-                Name = $parameterSetDetail.ParameterSetName
+                Name      = $parameterSetDetail.ParameterSetName
                 Mandatory = '$false'
             }
         }
 
         if ($skipParameterToAdd -and $parameterSetDetail.ContainsKey('x-ms-pageable') -and $parameterSetDetail.'x-ms-pageable' -and (-not $isNextPageOperation)) {
             $skipParameterToAdd.ParameterSetInfo[$parameterSetDetail.ParameterSetName] = @{
-                Name = $parameterSetDetail.ParameterSetName
+                Name      = $parameterSetDetail.ParameterSetName
                 Mandatory = '$false'
             }
         }
@@ -985,7 +1086,8 @@ function New-SwaggerPath
     $PageTypePagingObjectStr = $null
     if ($pagingOperations) {
         $pagingOperationCall = $executionContext.InvokeCommand.ExpandString($PagingOperationCallFunction)
-    } elseif ($Cmdlet) {
+    }
+    elseif ($Cmdlet) {
         $pagingOperationCall = $executionContext.InvokeCommand.ExpandString($PagingOperationCallCmdlet)
     }
 
@@ -1011,12 +1113,14 @@ function New-SwaggerPath
         $description = $defaultParameterSet.Description
         $synopsis = $defaultParameterSet.Synopsis
         Write-Warning -Message ($LocalizedData.CmdletHasAmbiguousParameterSets -f ($commandName))
-    } elseif ($nonUniqueParameterSets.Length -eq 1) {
+    }
+    elseif ($nonUniqueParameterSets.Length -eq 1) {
         # If there's only one non-unique, we can prevent errors by making this the default
         $DefaultParameterSetName = $nonUniqueParameterSets[0].ParameterSetName
         $description = $nonUniqueParameterSets[0].Description
         $synopsis = $nonUniqueParameterSets[0].Synopsis
-    } else {
+    }
+    else {
         # Pick the highest priority set among all sets
         $defaultParameterSet = $parameterSetDetails | Sort-Object @{e = {$_.Priority -as [int] }} | Select-Object -First 1
         $DefaultParameterSetName = $defaultParameterSet.ParameterSetName
@@ -1038,11 +1142,11 @@ function New-SwaggerPath
         if ($parameterToAdd) {
             $parameterName = $parameterToAdd.Details.Name
             
-            if($parameterToAdd.Details.Containskey('ValueFromPipeline') -and $parameterToAdd.Details.ValueFromPipeline) {
+            if ($parameterToAdd.Details.Containskey('ValueFromPipeline') -and $parameterToAdd.Details.ValueFromPipeline) {
                 $ValueFromPipelineString = ', ValueFromPipeline = $true'
             }
 
-            if($parameterToAdd.Details.Containskey('ValueFromPipelineByPropertyName') -and $parameterToAdd.Details.ValueFromPipelineByPropertyName) {
+            if ($parameterToAdd.Details.Containskey('ValueFromPipelineByPropertyName') -and $parameterToAdd.Details.ValueFromPipelineByPropertyName) {
                 $ValueFromPipelineByPropertyNameString = ', ValueFromPipelineByPropertyName = $true'
             }
 
@@ -1054,7 +1158,8 @@ function New-SwaggerPath
                 if ($AllParameterSetsString) {
                     # Two tabs
                     $AllParameterSetsString += [Environment]::NewLine + "        " + $executionContext.InvokeCommand.ExpandString($parameterAttributeString)
-                } else {
+                }
+                else {
                     $AllParameterSetsString = $executionContext.InvokeCommand.ExpandString($parameterAttributeString)
                 }
             }
@@ -1069,8 +1174,7 @@ function New-SwaggerPath
             # Parameter has Name as an alias, change the parameter name to Name and add the current parameter name as an alias.            
             if ($parameterToAdd.Details.Containskey('Alias') -and 
                 $parameterToAdd.Details.Alias -and
-                ($parameterToAdd.Details.Alias -eq 'Name'))
-            {
+                ($parameterToAdd.Details.Alias -eq 'Name')) {
                 $ParameterAliasMapping[$parameterName] = 'Name'
                 $AliasString = "'$parameterName'"
                 $parameterName = 'Name'
@@ -1079,8 +1183,7 @@ function New-SwaggerPath
 
             $paramName = "`$$parameterName"
             $ValidateSetDefinition = $null
-            if ($parameterToAdd.Details.ValidateSet)
-            {
+            if ($parameterToAdd.Details.ValidateSet) {
                 $ValidateSetString = $parameterToAdd.Details.ValidateSet
                 $ValidateSetDefinition = $executionContext.InvokeCommand.ExpandString($ValidateSetDefinitionString)
             }
@@ -1091,7 +1194,8 @@ function New-SwaggerPath
                 if ($parameterToAdd.Details.ExtendedData.ContainsKey('IsODataParameter') -and $parameterToAdd.Details.ExtendedData.IsODataParameter) {
                     $paramType = "[$($parameterToAdd.Details.Type)]$paramType"
                     $oDataExpression += "    if (`$$parameterName) { `$oDataQuery += `"&```$$parameterName=`$$parameterName`" }" + [Environment]::NewLine
-                } else {
+                }
+                else {
                     # Assuming you can't group ODataQuery parameters
                     if ($parameterToAdd.Details.ContainsKey('x_ms_parameter_grouping') -and $parameterToAdd.Details.'x_ms_parameter_grouping') {
                         $parameterGroupPropertyName = $parameterToAdd.Details.Name
@@ -1099,7 +1203,8 @@ function New-SwaggerPath
                         $fullGroupName = $parameterToAdd.Details.ExtendedData.GroupType
                         if ($parameterGroupsExpressions.ContainsKey($groupName)) {
                             $parameterGroupsExpression = $parameterGroupsExpressions[$groupName]
-                        } else {
+                        }
+                        else {
                             $parameterGroupsExpression = $executionContext.InvokeCommand.ExpandString($parameterGroupCreateExpression)
                         }
 
@@ -1113,12 +1218,15 @@ function New-SwaggerPath
                             if ($parameterToAdd.Details.ExtendedData.DefaultValue) {
                                 if ([NullString]::Value -eq $parameterToAdd.Details.ExtendedData.DefaultValue) {
                                     $parameterDefaultValue = "[NullString]::Value"
-                                } elseif ("System.String" -eq $parameterToAdd.Details.ExtendedData.Type) {
+                                }
+                                elseif ("System.String" -eq $parameterToAdd.Details.ExtendedData.Type) {
                                     $parameterDefaultValue = "`"$($parameterToAdd.Details.ExtendedData.DefaultValue)`""
-                                } else {
+                                }
+                                else {
                                     $parameterDefaultValue = "$($parameterToAdd.Details.ExtendedData.DefaultValue)"
                                 }
-                            } else {
+                            }
+                            else {
                                 $parameterDefaultValue = "`$null"
                             }
 
@@ -1130,13 +1238,15 @@ function New-SwaggerPath
                 $paramBlock += $executionContext.InvokeCommand.ExpandString($parameterDefString)
                 $pDescription = $parameterToAdd.Details.Description
                 $paramHelp += $executionContext.InvokeCommand.ExpandString($helpParamStr)
-            } elseif($parameterToAdd.Details.Containskey('Type')) {
+            }
+            elseif ($parameterToAdd.Details.Containskey('Type')) {
                 $paramType = "[$($parameterToAdd.Details.Type)]$paramType"
 
                 $paramblock += $executionContext.InvokeCommand.ExpandString($parameterDefString)
                 $pDescription = $parameterToAdd.Details.Description
                 $paramHelp += $executionContext.InvokeCommand.ExpandString($helpParamStr)
-            } else {
+            }
+            else {
                 Write-Warning ($LocalizedData.ParameterMissingFromAutoRestCode -f ($parameterName, $commandName))
             }
         }
@@ -1156,36 +1266,39 @@ function New-SwaggerPath
     if ($isLongRunningOperation) {
         if ($paramBlock) {
             $ParamBlockReplaceStr = $paramBlock + ",`r`n" + $AsJobParameterString
-        } else {
+        }
+        else {
             $ParamBlockReplaceStr = $AsJobParameterString
         }
 
         $PathFunctionBody = $executionContext.InvokeCommand.ExpandString($PathFunctionBodyAsJob)
-    } else {
+    }
+    else {
         $ParamBlockReplaceStr = $paramBlock
         $PathFunctionBody = $executionContext.InvokeCommand.ExpandString($PathFunctionBodySynch)
     }
 
     $functionBodyParams = @{
-        ParameterSetDetails               = $parameterSetDetails
-        ODataExpressionBlock              = $oDataExpressionBlock
-        ParameterGroupsExpressionBlock    = $parameterGroupsExpressionBlock
-        SwaggerDict                       = $SwaggerDict
-        SwaggerMetaDict                   = $SwaggerMetaDict
-        FlattenedParametersOnPSCmdlet     = $flattenedParametersOnPSCmdlet
-        ParameterAliasMapping             = $ParameterAliasMapping
+        ParameterSetDetails            = $parameterSetDetails
+        ODataExpressionBlock           = $oDataExpressionBlock
+        ParameterGroupsExpressionBlock = $parameterGroupsExpressionBlock
+        SwaggerDict                    = $SwaggerDict
+        SwaggerMetaDict                = $SwaggerMetaDict
+        FlattenedParametersOnPSCmdlet  = $flattenedParametersOnPSCmdlet
+        ParameterAliasMapping          = $ParameterAliasMapping
+        FilterBlock                    = $FilterBlock
     }
-    if($AuthenticationCommand) {
+    if ($AuthenticationCommand) {
         $functionBodyParams['AuthenticationCommand'] = $AuthenticationCommand
         $functionBodyParams['AuthenticationCommandArgumentName'] = $AuthenticationCommandArgumentName
     }
-    if($AddHttpClientHandler) {
+    if ($AddHttpClientHandler) {
         $functionBodyParams['AddHttpClientHandler'] = $AddHttpClientHandler
     }    
-    if($hostOverrideCommand) {
+    if ($hostOverrideCommand) {
         $functionBodyParams['hostOverrideCommand'] = $hostOverrideCommand
     }
-    if($globalParameters) {
+    if ($globalParameters) {
         $functionBodyParams['GlobalParameters'] = $globalParameters
     }
     if ($globalParametersStatic) {
@@ -1196,7 +1309,7 @@ function New-SwaggerPath
     $bodyObject = $pathGenerationPhaseResult.BodyObject
 
     $body = $bodyObject.Body
-    if($PSCmdletOutputItemType){
+    if ($PSCmdletOutputItemType) {
         $fullPathDataType = $PSCmdletOutputItemType
         $outputTypeBlock = $executionContext.InvokeCommand.ExpandString($outputTypeStr)
     }
@@ -1206,15 +1319,16 @@ function New-SwaggerPath
 
     if ($UseAzureCsharpGenerator) {
         $dependencyInitFunction = "Initialize-PSSwaggerDependencies -Azure"
-    } else {
+    }
+    else {
         $dependencyInitFunction = "Initialize-PSSwaggerDependencies"
     }
     
     $CommandString = $executionContext.InvokeCommand.ExpandString($advFnSignatureForPath)
     $GeneratedCommandsPath = Join-Path -Path (Join-Path -Path $SwaggerMetaDict['outputDirectory'] -ChildPath $GeneratedCommandsName) `
-                                       -ChildPath 'SwaggerPathCommands'
+        -ChildPath 'SwaggerPathCommands'
 
-    if(-not (Test-Path -Path $GeneratedCommandsPath -PathType Container)) {
+    if (-not (Test-Path -Path $GeneratedCommandsPath -PathType Container)) {
         $null = New-Item -Path $GeneratedCommandsPath -ItemType Directory
     }
 
@@ -1230,18 +1344,18 @@ function Set-ExtendedCodeMetadata {
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]
         $MainClientTypeName,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]
         $CliXmlTmpPath
     )
 
     $resultRecord = @{
         VerboseMessages = @()
-        ErrorMessages = @()
+        ErrorMessages   = @()
         WarningMessages = @()
     }
     
@@ -1261,17 +1375,17 @@ function Set-ExtendedCodeMetadata {
             $methodNames = @()
             $operations = ''
             $operationsWithSuffix = ''
-            $opIdValues = $operationId -split '_',2 
-            if(-not $opIdValues -or ($opIdValues.count -ne 2)) {
+            $opIdValues = $operationId -split '_', 2 
+            if (-not $opIdValues -or ($opIdValues.count -ne 2)) {
                 # I'm sure there's other stuff but what? Need to check what AutoRest is using. Their CSharpNamer thing?
                 $methodNames += $operationId.Replace("-", "") + 'WithHttpMessagesAsync'
                 $methodNames += $operationId.Replace("-", "") + 'Method' + 'WithHttpMessagesAsync'
-            } else {            
+            }
+            else {            
                 $operationName = $opIdValues[0].Replace("-", "")
                 $operationType = $opIdValues[1].Replace("-", "")
                 $operations = ".$operationName"
-                if ($parameterSetDetail['UseOperationsSuffix'] -and $parameterSetDetail['UseOperationsSuffix'])
-                { 
+                if ($parameterSetDetail['UseOperationsSuffix'] -and $parameterSetDetail['UseOperationsSuffix']) { 
                     $operationsWithSuffix = $operations + 'Operations'
                 }
 
@@ -1298,16 +1412,15 @@ function Set-ExtendedCodeMetadata {
                 $matchingParamDetail = $paramObject.GetEnumerator() | Where-Object { $_.Value.Name -eq $propertyName } | Select-Object -First 1 -ErrorAction Ignore
                 if ($matchingParamDetail) {
                     $setSingleParameterMetadataParms = @{
-                                                            CommandName = $FunctionDetails['CommandName']
-                                                            Name = $matchingParamDetail.Value.Name
-                                                            HasDefaultValue = $false
-                                                            IsGrouped = $false
-                                                            Type = $_.PropertyType
-                                                            MatchingParamDetail = $matchingParamDetail.Value
-                                                            ResultRecord = $resultRecord
-                                                        }
-                    if (-not (Set-SingleParameterMetadata @setSingleParameterMetadataParms))
-                    {
+                        CommandName         = $FunctionDetails['CommandName']
+                        Name                = $matchingParamDetail.Value.Name
+                        HasDefaultValue     = $false
+                        IsGrouped           = $false
+                        Type                = $_.PropertyType
+                        MatchingParamDetail = $matchingParamDetail.Value
+                        ResultRecord        = $resultRecord
+                    }
+                    if (-not (Set-SingleParameterMetadata @setSingleParameterMetadataParms)) {
                         Export-CliXml -InputObject $ResultRecord -Path $CliXmlTmpPath
                         $errorOccurred = $true
                         return
@@ -1328,12 +1441,14 @@ function Set-ExtendedCodeMetadata {
                         $errorOccurred = $true
                         return
                     }
-                } else {
+                }
+                else {
                     $parameterSetDetail['Operations'] = $operationsWithSuffix
                 }
 
                 $clientType = $propertyObject.PropertyType
-            } elseif ($operations) {
+            }
+            elseif ($operations) {
                 $operationName = $operations.Substring(1)
                 $propertyObject = $clientType.GetProperties() | Where-Object { $_.Name -eq $operationName } | Select-Object -First 1 -ErrorAction Ignore
                 if (-not $propertyObject) {
@@ -1379,9 +1494,9 @@ function Set-ExtendedCodeMetadata {
                 # All Types should be converted to their string names, otherwise the CLI XML gets too large
                 $type = $_.ParameterType.ToString()
                 $metadata = @{
-                    Name = Get-PascalCasedString -Name $_.Name
+                    Name            = Get-PascalCasedString -Name $_.Name
                     HasDefaultValue = $hasDefaultValue
-                    Type = $type
+                    Type            = $type
                 }
 
                 $matchingParamDetail = $paramObject.GetEnumerator() | Where-Object { $_.Value.Name -eq $metadata.Name } | Select-Object -First 1 -ErrorAction Ignore
@@ -1397,17 +1512,16 @@ function Set-ExtendedCodeMetadata {
                             $matchingGroupedParameterDetailEntry = $matchingParamDetail.'x_ms_parameter_grouping_group'.GetEnumerator() | Where-Object { $_.Value.Name -eq $parameterGroupProperty.Name } | Select-Object -First 1 -ErrorAction Ignore
                             if ($matchingGroupedParameterDetailEntry) {
                                 $setSingleParameterMetadataParms = @{
-                                    CommandName = $FunctionDetails['CommandName']
-                                    Name = $matchingParamDetail.Name
-                                    HasDefaultValue = $false
-                                    IsGrouped = $true
-                                    Type = $_.PropertyType
+                                    CommandName         = $FunctionDetails['CommandName']
+                                    Name                = $matchingParamDetail.Name
+                                    HasDefaultValue     = $false
+                                    IsGrouped           = $true
+                                    Type                = $_.PropertyType
                                     MatchingParamDetail = $matchingGroupedParameterDetailEntry.Value
-                                    ResultRecord = $resultRecord
+                                    ResultRecord        = $resultRecord
                                 }
 
-                                if (-not (Set-SingleParameterMetadata @setSingleParameterMetadataParms))
-                                {
+                                if (-not (Set-SingleParameterMetadata @setSingleParameterMetadataParms)) {
                                     Export-CliXml -InputObject $ResultRecord -Path $CliXmlTmpPath
                                     $errorOccurred = $true
                                     return
@@ -1416,24 +1530,24 @@ function Set-ExtendedCodeMetadata {
                                 $matchingGroupedParameterDetailEntry.Value.ExtendedData.GroupType = $parameterGroupType.ToString()
                             }
                         }
-                    } else {
+                    }
+                    else {
                         # Single parameter
                         $setSingleParameterMetadataParms = @{
-                            CommandName = $FunctionDetails['CommandName']
-                            Name = $_.Name
-                            HasDefaultValue = $hasDefaultValue
-                            IsGrouped = $false
-                            Type = $_.ParameterType
+                            CommandName         = $FunctionDetails['CommandName']
+                            Name                = $_.Name
+                            HasDefaultValue     = $hasDefaultValue
+                            IsGrouped           = $false
+                            Type                = $_.ParameterType
                             MatchingParamDetail = $matchingParamDetail
-                            ResultRecord = $resultRecord
+                            ResultRecord        = $resultRecord
                         }
 
                         if ($hasDefaultValue) {
                             $setSingleParameterMetadataParms['DefaultValue'] = $_.DefaultValue
                         }
 
-                        if (-not (Set-SingleParameterMetadata @setSingleParameterMetadataParms))
-                        {
+                        if (-not (Set-SingleParameterMetadata @setSingleParameterMetadataParms)) {
                             Export-CliXml -InputObject $ResultRecord -Path $CliXmlTmpPath
                             $errorOccurred = $true
                             return
@@ -1443,13 +1557,15 @@ function Set-ExtendedCodeMetadata {
                     }
                     
                     $ParamList += $paramToAdd
-                } else {
+                }
+                else {
                     if ($metadata.Type.StartsWith("Microsoft.Rest.Azure.OData.ODataQuery``1")) {
                         if ($oDataQueryFound) {
                             $resultRecord.ErrorMessages += ($LocalizedData.MultipleODataQueriesOneFunction -f ($operationId))
                             Export-CliXml -InputObject $resultRecord -Path $CliXmlTmpPath
                             return
-                        } else {
+                        }
+                        else {
                             # Escape backticks
                             $oDataQueryType = $metadata.Type.Replace("``", "````")
                             $ParamList += "`$(if (`$oDataQuery) { New-Object -TypeName `"$oDataQueryType`" -ArgumentList `$oDataQuery } else { `$null })"
@@ -1486,7 +1602,7 @@ function Set-ExtendedCodeMetadata {
 
 function Convert-GenericTypeToString {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [Type]$Type
     )
 
@@ -1505,46 +1621,46 @@ function Convert-GenericTypeToString {
 
 function Set-SingleParameterMetadata {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]
         $CommandName,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]
         $Name,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [bool]
         $HasDefaultValue,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [bool]
         $IsGrouped,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [System.Type]
         $Type,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $MatchingParamDetail,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [hashtable]
         $ResultRecord,
 
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [object]
         $DefaultValue
     )
     
     $name = Get-PascalCasedString -Name $_.Name
     $metadata = @{
-                    Name = $name
-                    HasDefaultValue = $HasDefaultValue
-                    Type = $Type.ToString()
-                    ParamToAdd = "`$$name"
-                }
+        Name            = $name
+        HasDefaultValue = $HasDefaultValue
+        Type            = $Type.ToString()
+        ParamToAdd      = "`$$name"
+    }
 
     if ($HasDefaultValue) {
         # Setting this default value actually matter, but we might as well
@@ -1554,13 +1670,15 @@ function Set-SingleParameterMetadata {
                 # This is the part that works around PS automatic string coercion
                 $metadata.ParamToAdd = "`$(if (`$PSBoundParameters.ContainsKey('$($metadata.Name)')) { $($metadata.ParamToAdd) } else { [NullString]::Value })"
             }
-        } elseif ("System.Nullable``1[System.Boolean]" -eq $metadata.Type) {
-            if($DefaultValue -ne $null) {
+        }
+        elseif ("System.Nullable``1[System.Boolean]" -eq $metadata.Type) {
+            if ($DefaultValue -ne $null) {
                 $DefaultValue = "`$$DefaultValue"
             }
 
             $metadata.Type = "switch"
-        } else {
+        }
+        else {
             $DefaultValue = $_.DefaultValue
             if (-not ($_.ParameterType.IsValueType) -and $DefaultValue) {
                 $ResultRecord.ErrorMessages += $LocalizedData.ReferenceTypeDefaultValueNotSupported -f ($metadata.Name, $metadata.Type, $CommandName)
@@ -1569,7 +1687,8 @@ function Set-SingleParameterMetadata {
         }
 
         $metadata['DefaultValue'] = $DefaultValue
-    } else {
+    }
+    else {
         if ('$false' -eq $matchingParamDetail.Mandatory -and (-not $IsGrouped)) {
             # This happens in the case of optional path parameters, even if the path parameter is at the end
             $ResultRecord.WarningMessages += ($LocalizedData.OptionalParameterNowRequired -f ($metadata.Name, $CommandName))
@@ -1582,7 +1701,7 @@ function Set-SingleParameterMetadata {
 
 function Get-TemporaryCliXmlFilePath {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]
         $FullClientTypeName
     )
@@ -1602,16 +1721,18 @@ function Get-TemporaryCliXmlFilePath {
 #>
 function Get-ValueText {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [object]
         $obj
     )
 
     if ($obj -is [string]) {
         return "'$obj'"
-    } elseif ($obj -is [bool]) {
+    }
+    elseif ($obj -is [bool]) {
         return "`$$obj"
-    } else {
+    }
+    else {
         return $obj
     }
 }

--- a/PSSwagger/ServiceTypes/azure.PSMeta.json
+++ b/PSSwagger/ServiceTypes/azure.PSMeta.json
@@ -1,5 +1,7 @@
 {
   "info": {
-    "x-ps-code-generation-settings": {}
+    "x-ps-code-generation-settings": {
+      "defaultWildcardChar": "*"
+    }
   }
 }

--- a/PSSwagger/ServiceTypes/azure.PSMeta.json
+++ b/PSSwagger/ServiceTypes/azure.PSMeta.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "x-ps-code-generation-settings": {
-      "defaultWildcardChar": "*"
+      "defaultWildcardChar": "%"
     }
   }
 }

--- a/PSSwagger/ServiceTypes/azure.PSMeta.json
+++ b/PSSwagger/ServiceTypes/azure.PSMeta.json
@@ -1,7 +1,9 @@
 {
   "info": {
     "x-ps-code-generation-settings": {
-      "defaultWildcardChar": "%"
+      "azureDefaults": {
+        "clientSideFiltering": false
+      }
     }
   }
 }

--- a/PSSwagger/ServiceTypes/azure_stack.PSMeta.json
+++ b/PSSwagger/ServiceTypes/azure_stack.PSMeta.json
@@ -1,7 +1,9 @@
 {
   "info": {
     "x-ps-code-generation-settings": {
-      "defaultWildcardChar": "%"
+      "azureDefaults": {
+        "clientSideFiltering": true
+      }
     }
   }
 }

--- a/PSSwagger/ServiceTypes/azure_stack.PSMeta.json
+++ b/PSSwagger/ServiceTypes/azure_stack.PSMeta.json
@@ -1,5 +1,7 @@
 {
   "info": {
-    "x-ps-code-generation-settings": {}
+    "x-ps-code-generation-settings": {
+      "defaultWildcardChar": "*"
+    }
   }
 }

--- a/PSSwagger/ServiceTypes/azure_stack.PSMeta.json
+++ b/PSSwagger/ServiceTypes/azure_stack.PSMeta.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "x-ps-code-generation-settings": {
-      "defaultWildcardChar": "*"
+      "defaultWildcardChar": "%"
     }
   }
 }

--- a/PSSwagger/SwaggerUtils.psm1
+++ b/PSSwagger/SwaggerUtils.psm1
@@ -1510,7 +1510,11 @@ function Get-PathFunctionBody
 
         [Parameter(Mandatory=$false)]
         [PSCustomObject]
-        $GlobalParametersStatic
+        $GlobalParametersStatic,
+
+        [Parameter(Mandatory=$false)]
+        [string]
+        $FilterBlock
     )
 
     Get-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState

--- a/PSSwagger/Test-FilteredResult.ps1
+++ b/PSSwagger/Test-FilteredResult.ps1
@@ -27,6 +27,8 @@ function Test-FilteredResult {
         Test-WildcardFilterOnResult -Filter $Filter -Result $Result
     } elseif ($Filter.Type -eq 'equalityOperator') {
         Test-EqualityFilterOnResult -Filter $Filter -Result $Result
+    } elseif ($Filter.Type -eq 'powershellWildcard') {
+        Test-PSWildcardFilterOnResult -Filter $Filter -Result $Result
     }
 }
 
@@ -76,4 +78,20 @@ function Test-EqualityFilterOnResult {
     } elseif ($Filter.Operation -eq '>') {
         ($Result.($Filter.Property) -gt $Filter.Value)
     }
+}
+
+function Test-PSWildcardFilterOnResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [object]
+        $Result,
+
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]
+        $Filter
+    )
+
+    $pattern = [WildcardPattern]::Get($Filter.Value, [System.Management.Automation.WildcardOptions]::IgnoreCase)
+    $pattern.IsMatch(($Result.($Filter.Property)))
 }

--- a/PSSwagger/Test-FilteredResult.ps1
+++ b/PSSwagger/Test-FilteredResult.ps1
@@ -42,7 +42,7 @@ function Test-WildcardFilterOnResult {
         $Filter
     )
 
-    foreach ($char in $Filter.Value) {
+    foreach ($char in $Filter.Value.ToCharArray()) {
         if ($char -ne $Filter.Character) {
             $regex += "[$char]"
         } else {
@@ -50,7 +50,6 @@ function Test-WildcardFilterOnResult {
         }
     }
 
-    $regex = $regex.Replace($Filter.Character, ".*")
     ($Result.($Filter.Property)) -match $regex
 }
 

--- a/PSSwagger/Test-FilteredResult.ps1
+++ b/PSSwagger/Test-FilteredResult.ps1
@@ -25,8 +25,8 @@ function Test-FilteredResult {
     $ErrorActionPreference = 'Stop'
     if ($Filter.Type -eq 'wildcard') {
         Test-WildcardFilterOnResult -Filter $Filter -Result $Result
-    } elseif ($Filter.Type -eq 'logicalOperation') {
-        Test-LogicalFilterOnResult -Filter $Filter -Result $Result
+    } elseif ($Filter.Type -eq 'equalityOperator') {
+        Test-EqualityFilterOnResult -Filter $Filter -Result $Result
     }
 }
 
@@ -46,7 +46,7 @@ function Test-WildcardFilterOnResult {
     ($Result.($Filter.Property)) -match $regex
 }
 
-function Test-LogicalFilterOnResult {
+function Test-EqualityFilterOnResult {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]

--- a/PSSwagger/Test-FilteredResult.ps1
+++ b/PSSwagger/Test-FilteredResult.ps1
@@ -1,0 +1,72 @@
+Microsoft.PowerShell.Core\Set-StrictMode -Version Latest
+
+<#
+.DESCRIPTION
+   Determines if a result matches the given filter.
+
+.PARAMETER  Result
+    Result to filter
+
+.PARAMETER  Filter
+    Filter to apply
+#>
+function Test-FilteredResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [object]
+        $Result,
+
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]
+        $Filter
+    )
+
+    $ErrorActionPreference = 'Stop'
+    if ($Filter.Type -eq 'wildcard') {
+        Test-WildcardFilterOnResult -Filter $Filter -Result $Result
+    } elseif ($Filter.Type -eq 'logicalOperation') {
+        Test-LogicalFilterOnResult -Filter $Filter -Result $Result
+    }
+}
+
+function Test-WildcardFilterOnResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [object]
+        $Result,
+
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]
+        $Filter
+    )
+
+    $regex = $Filter.Value.Replace($Filter.Character, ".*")
+    ($Result.($Filter.Property)) -match $regex
+}
+
+function Test-LogicalFilterOnResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [object]
+        $Result,
+
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]
+        $Filter
+    )
+
+    if ($Filter.Operation -eq '<') {
+        ($Result.($Filter.Property) -lt $Filter.Value)
+    } elseif ($Filter.Operation -eq '<=') {
+        ($Result.($Filter.Property) -le $Filter.Value)
+    } elseif ($Filter.Operation -eq '=') {
+        ($Result.($Filter.Property) -eq $Filter.Value)
+    } elseif ($Filter.Operation -eq '>=') {
+        ($Result.($Filter.Property) -ge $Filter.Value)
+    } elseif ($Filter.Operation -eq '>') {
+        ($Result.($Filter.Property) -gt $Filter.Value)
+    }
+}

--- a/PSSwagger/Test-FilteredResult.ps1
+++ b/PSSwagger/Test-FilteredResult.ps1
@@ -42,7 +42,15 @@ function Test-WildcardFilterOnResult {
         $Filter
     )
 
-    $regex = $Filter.Value.Replace($Filter.Character, ".*")
+    foreach ($char in $Filter.Value) {
+        if ($char -ne $Filter.Character) {
+            $regex += "[$char]"
+        } else {
+            $regex += ".*"
+        }
+    }
+
+    $regex = $regex.Replace($Filter.Character, ".*")
     ($Result.($Filter.Property)) -match $regex
 }
 

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -1365,6 +1365,10 @@ Describe 'Client-side filtering tests (using metadata file)' -Tag @('ClientSideF
         ((Get-Resource -LastCreatedOn ([DateTime]::Parse("1/20/2018 12:07:21 PM"))).Count) | should be 2
     }
 
+    It 'Multiple filters are &&ed together' {
+        ((Get-Resource -Name *y* -MaxUsers 100).Count) | should be 1
+    }
+
     AfterAll {
         Stop-JsonServer -JsonServerProcess $processes.ServerProcess -NodeProcess $processes.NodeProcess
     }
@@ -1414,6 +1418,10 @@ Describe 'Client-side filtering tests (using spec)' -Tag @('ClientSideFilter', '
 
     It 'Filters dateTime with greater than or equal to' {
         ((Get-Resource -LastCreatedOn ([DateTime]::Parse("1/20/2018 12:07:21 PM"))).Count) | should be 2
+    }
+
+    It 'Multiple filters are &&ed together' {
+        ((Get-Resource -Name *y* -MaxUsers 100).Count) | should be 1
     }
 
     AfterAll {

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -1346,11 +1346,10 @@ Describe 'Client-side filtering tests (using metadata file)' -Tag @('ClientSideF
 
     It 'Adds append parameters' {
         $cmdInfo = Get-Command Get-Resource
-        $parameterSet = $cmdInfo.ParameterSets | Where-Object { $_.Name -eq "Resources_Get" }
-        $CommandInfo.Parameters.Keys -contains 'MaxUsers' | Should Be $true
-        $CommandInfo.Parameters.MaxUsers.ParameterType.ToString() | Should BeExactly 'System.Int32'
-        $CommandInfo.Parameters.Keys -contains 'LastCreatedOn' | Should Be $true
-        $CommandInfo.Parameters.LastCreatedOn.ParameterType.ToString() | Should BeExactly 'System.DateTime'
+        $cmdInfo.Parameters.Keys -contains 'MaxUsers' | Should Be $true
+        $cmdInfo.Parameters.MaxUsers.ParameterType.ToString() | Should BeExactly 'System.Int32'
+        $cmdInfo.Parameters.Keys -contains 'LastCreatedOn' | Should Be $true
+        $cmdInfo.Parameters.LastCreatedOn.ParameterType.ToString() | Should BeExactly 'System.DateTime'
     }
 
     It 'Filters name with wildcard' {
@@ -1358,15 +1357,15 @@ Describe 'Client-side filtering tests (using metadata file)' -Tag @('ClientSideF
     }
 
     It 'Filters users with less than' {
-        ((Get-Resource -MaxUsers 50).Count) | should be 2
+        ((Get-Resource -Name abdef -MaxUsers 50).Count) | should be 1
     }
 
     It 'Filters dateTime with greater than or equal to' {
-        ((Get-Resource -LastCreatedOn ([DateTime]::Parse("1/20/2018 12:07:21 PM"))).Count) | should be 2
+        ((Get-Resource -Name * -LastCreatedOn ([DateTime]::Parse("1/20/2018 12:07:21 PM"))).Count) | should be 2
     }
 
     It 'Multiple filters are &&ed together' {
-        ((Get-Resource -Name *y* -MaxUsers 100).Count) | should be 1
+        ((Get-Resource -Name * -MaxUsers 100).Count) | should be 2
     }
 
     AfterAll {
@@ -1401,11 +1400,10 @@ Describe 'Client-side filtering tests (using spec)' -Tag @('ClientSideFilter', '
 
     It 'Adds append parameters' {
         $cmdInfo = Get-Command Get-Resource
-        $parameterSet = $cmdInfo.ParameterSets | Where-Object { $_.Name -eq "Resources_Get" }
-        $CommandInfo.Parameters.Keys -contains 'MaxUsers' | Should Be $true
-        $CommandInfo.Parameters.MaxUsers.ParameterType.ToString() | Should BeExactly 'System.Int32'
-        $CommandInfo.Parameters.Keys -contains 'LastCreatedOn' | Should Be $true
-        $CommandInfo.Parameters.LastCreatedOn.ParameterType.ToString() | Should BeExactly 'System.DateTime'
+        $cmdInfo.Parameters.Keys -contains 'MaxUsers' | Should Be $true
+        $cmdInfo.Parameters.MaxUsers.ParameterType.ToString() | Should BeExactly 'System.Int32'
+        $cmdInfo.Parameters.Keys -contains 'LastCreatedOn' | Should Be $true
+        $cmdInfo.Parameters.LastCreatedOn.ParameterType.ToString() | Should BeExactly 'System.DateTime'
     }
 
     It 'Filters name with wildcard' {
@@ -1413,15 +1411,15 @@ Describe 'Client-side filtering tests (using spec)' -Tag @('ClientSideFilter', '
     }
 
     It 'Filters users with less than' {
-        ((Get-Resource -MaxUsers 50).Count) | should be 2
+        ((Get-Resource -Name abdef -MaxUsers 50).Count) | should be 1
     }
 
     It 'Filters dateTime with greater than or equal to' {
-        ((Get-Resource -LastCreatedOn ([DateTime]::Parse("1/20/2018 12:07:21 PM"))).Count) | should be 2
+        ((Get-Resource -Name * -LastCreatedOn ([DateTime]::Parse("1/20/2018 12:07:21 PM"))).Count) | should be 2
     }
 
     It 'Multiple filters are &&ed together' {
-        ((Get-Resource -Name *y* -MaxUsers 100).Count) | should be 1
+        ((Get-Resource -Name * -MaxUsers 100).Count) | should be 2
     }
 
     AfterAll {

--- a/Tests/PSSwaggerScenario.Tests.ps1
+++ b/Tests/PSSwaggerScenario.Tests.ps1
@@ -1347,8 +1347,10 @@ Describe 'Client-side filtering tests (using metadata file)' -Tag @('ClientSideF
     It 'Adds append parameters' {
         $cmdInfo = Get-Command Get-Resource
         $parameterSet = $cmdInfo.ParameterSets | Where-Object { $_.Name -eq "Resources_Get" }
-        ($parameterSet.Parameters | Where-Object { $_.Name -eq "LastCreatedOn" }) | should not be $null
-        ($parameterSet.Parameters | Where-Object { $_.Name -eq "MaxUsers" }) | should not be $null
+        $CommandInfo.Parameters.Keys -contains 'MaxUsers' | Should Be $true
+        $CommandInfo.Parameters.MaxUsers.ParameterType.ToString() | Should BeExactly 'System.Int32'
+        $CommandInfo.Parameters.Keys -contains 'LastCreatedOn' | Should Be $true
+        $CommandInfo.Parameters.LastCreatedOn.ParameterType.ToString() | Should BeExactly 'System.DateTime'
     }
 
     It 'Filters name with wildcard' {
@@ -1396,8 +1398,10 @@ Describe 'Client-side filtering tests (using spec)' -Tag @('ClientSideFilter', '
     It 'Adds append parameters' {
         $cmdInfo = Get-Command Get-Resource
         $parameterSet = $cmdInfo.ParameterSets | Where-Object { $_.Name -eq "Resources_Get" }
-        ($parameterSet.Parameters | Where-Object { $_.Name -eq "LastCreatedOn" }) | should not be $null
-        ($parameterSet.Parameters | Where-Object { $_.Name -eq "MaxUsers" }) | should not be $null
+        $CommandInfo.Parameters.Keys -contains 'MaxUsers' | Should Be $true
+        $CommandInfo.Parameters.MaxUsers.ParameterType.ToString() | Should BeExactly 'System.Int32'
+        $CommandInfo.Parameters.Keys -contains 'LastCreatedOn' | Should Be $true
+        $CommandInfo.Parameters.LastCreatedOn.ParameterType.ToString() | Should BeExactly 'System.DateTime'
     }
 
     It 'Filters name with wildcard' {

--- a/Tests/data/ClientSideFilterTests/ClientSideFilterBasicSpec.json
+++ b/Tests/data/ClientSideFilterTests/ClientSideFilterBasicSpec.json
@@ -1,0 +1,90 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "2018-01-16",
+        "title": "ClientSideFilterBasic",
+        "description": "Basic spec for client-side filter test"
+    },
+    "host": "localhost:3000",
+    "schemes": [
+        "http"
+    ],
+    "security": [],
+    "securityDefinitions": {},
+    "paths": {
+        "/resources/{name}": {
+            "get": {
+                "operationId": "Resources_Get",
+                "description": "Get a single resource by name",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "Name of resource"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieved resources",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resource"
+                            }
+                        }
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ]
+            }
+        },
+        "/resources": {
+            "get": {
+                "operationId": "Resources_List",
+                "description": "Get all resources",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "Retrieved resources",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resource"
+                            }
+                        }
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ]
+            }
+        }
+    },
+    "definitions": {
+        "Resource": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "users": {
+                    "type": "integer"
+                },
+                "createdOn": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            },
+            "description": "A resource"
+        }
+    },
+    "parameters": {}
+}

--- a/Tests/data/ClientSideFilterTests/ClientSideFilterBasicSpec.psmeta.json
+++ b/Tests/data/ClientSideFilterTests/ClientSideFilterBasicSpec.psmeta.json
@@ -1,0 +1,44 @@
+{
+    "paths": {
+        "/resources/{name}": {
+            "get": {
+                "operationId": "Resources_Get",
+                "x-ps-cmdlet-infos": [{
+                    "clientSideFilter": {
+                        "serverSideResultCommand": ".",
+                        "serverSideResultParameterSet": "Resources_List",
+                        "clientSideParameterSet": "Resources_Get",
+                        "filters": [
+                            {
+                                "type": "wildcard",
+                                "parameter": "Name",
+                                "character": "*",
+                                "property": "Name"
+                            },
+                            {
+                                "type": "logicalOperation",
+                                "operation": ">=",
+                                "parameter": "LastCreatedOn",
+                                "appendParameterInfo": {
+                                    "type": "System.DateTime",
+                                    "required": false
+                                },
+                                "property": "CreatedOn"
+                            },
+                            {
+                                "type": "logicalOperation",
+                                "operation": "<",
+                                "parameter": "MaxUsers",
+                                "appendParameterInfo": {
+                                    "type": "int",
+                                    "required": false
+                                },
+                                "property": "Users"
+                            }
+                        ]
+                    }
+                }]
+            }
+        }
+    }
+}

--- a/Tests/data/ClientSideFilterTests/ClientSideFilterBasicSpec.psmeta.json
+++ b/Tests/data/ClientSideFilterTests/ClientSideFilterBasicSpec.psmeta.json
@@ -16,7 +16,7 @@
                                 "property": "Name"
                             },
                             {
-                                "type": "logicalOperation",
+                                "type": "equalityOperator",
                                 "operation": ">=",
                                 "parameter": "LastCreatedOn",
                                 "appendParameterInfo": {
@@ -26,7 +26,7 @@
                                 "property": "CreatedOn"
                             },
                             {
-                                "type": "logicalOperation",
+                                "type": "equalityOperator",
                                 "operation": "<",
                                 "parameter": "MaxUsers",
                                 "appendParameterInfo": {

--- a/Tests/data/ClientSideFilterTests/ClientSideFilterBasicSpec.psmeta.json
+++ b/Tests/data/ClientSideFilterTests/ClientSideFilterBasicSpec.psmeta.json
@@ -4,7 +4,7 @@
             "get": {
                 "operationId": "Resources_Get",
                 "x-ps-cmdlet-infos": [{
-                    "clientSideFilter": {
+                    "clientSideFilters": [{
                         "serverSideResultCommand": ".",
                         "serverSideResultParameterSet": "Resources_List",
                         "clientSideParameterSet": "Resources_Get",
@@ -36,7 +36,7 @@
                                 "property": "Users"
                             }
                         ]
-                    }
+                    }]
                 }]
             }
         }

--- a/Tests/data/ClientSideFilterTests/ClientSideFilterData.json
+++ b/Tests/data/ClientSideFilterTests/ClientSideFilterData.json
@@ -1,0 +1,19 @@
+{
+  "resources": [
+    {
+      "name": "abdef",
+      "users": 1,
+      "createdOn": "1/16/2018 12:07:21 PM"
+    },
+    {
+      "name": "defabghty",
+      "users": 10,
+      "createdOn": "1/20/2018 12:07:21 PM"
+    },
+    {
+      "name": "poiabuytr",
+      "users": 100,
+      "createdOn": "2/16/2018 12:07:21 PM"
+    }
+  ]
+}

--- a/Tests/data/ClientSideFilterTests/ClientSideFilterRoutes.json
+++ b/Tests/data/ClientSideFilterTests/ClientSideFilterRoutes.json
@@ -1,0 +1,3 @@
+{
+    "/resources/:name": "/resources?name=:name"
+}

--- a/Tests/data/ClientSideFilterTests/ClientSideFilterSpecWithMetadata.json
+++ b/Tests/data/ClientSideFilterTests/ClientSideFilterSpecWithMetadata.json
@@ -1,0 +1,122 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "2018-01-16",
+        "title": "ClientSideFilterBasic",
+        "description": "Basic spec for client-side filter test"
+    },
+    "host": "localhost:3000",
+    "schemes": [
+        "http"
+    ],
+    "security": [],
+    "securityDefinitions": {},
+    "paths": {
+        "/resources/{name}": {
+            "get": {
+                "operationId": "Resources_Get",
+                "description": "Get a single resource by name",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "path",
+                        "required": true,
+                        "type": "string",
+                        "description": "Name of resource"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Retrieved resources",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resource"
+                            }
+                        }
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "x-ps-cmdlet-infos": [{
+                    "clientSideFilter": {
+                        "serverSideResultCommand": ".",
+                        "serverSideResultParameterSet": "Resources_List",
+                        "filters": [
+                            {
+                                "type": "wildcard",
+                                "parameter": "Name",
+                                "character": "*",
+                                "property": "Name"
+                            },
+                            {
+                                "type": "lessThanLogical",
+                                "parameter": "LastCreatedOn",
+                                "appendParameterInfo": {
+                                    "type": "System.DateTime",
+                                    "required": false
+                                },
+                                "property": "CreatedOn"
+                            },
+                            {
+                                "type": "lessThanLogical",
+                                "parameter": "MaxUsers",
+                                "appendParameterInfo": {
+                                    "type": "int",
+                                    "required": false
+                                },
+                                "property": "Users"
+                            }
+                        ]
+                    }
+                }]
+            }
+        },
+        "/resources": {
+            "get": {
+                "operationId": "Resources_List",
+                "description": "Get all resources",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "Retrieved resources",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resource"
+                            }
+                        }
+                    }
+                },
+                "produces": [
+                    "application/json"
+                ],
+                "consumes": [
+                    "application/json"
+                ]
+            }
+        }
+    },
+    "definitions": {
+        "Resource": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "users": {
+                    "type": "integer"
+                },
+                "createdOn": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            },
+            "description": "A resource"
+        }
+    },
+    "parameters": {}
+}

--- a/Tests/data/ClientSideFilterTests/ClientSideFilterSpecWithMetadata.json
+++ b/Tests/data/ClientSideFilterTests/ClientSideFilterSpecWithMetadata.json
@@ -55,7 +55,7 @@
                                 "property": "Name"
                             },
                             {
-                                "type": "logicalOperation",
+                                "type": "equalityOperator",
                                 "operation": ">=",
                                 "parameter": "LastCreatedOn",
                                 "appendParameterInfo": {
@@ -65,7 +65,7 @@
                                 "property": "CreatedOn"
                             },
                             {
-                                "type": "logicalOperation",
+                                "type": "equalityOperator",
                                 "operation": "<",
                                 "parameter": "MaxUsers",
                                 "appendParameterInfo": {

--- a/Tests/data/ClientSideFilterTests/ClientSideFilterSpecWithMetadata.json
+++ b/Tests/data/ClientSideFilterTests/ClientSideFilterSpecWithMetadata.json
@@ -43,7 +43,7 @@
                     "application/json"
                 ],
                 "x-ps-cmdlet-infos": [{
-                    "clientSideFilter": {
+                    "clientSideFilters": [{
                         "serverSideResultCommand": ".",
                         "serverSideResultParameterSet": "Resources_List",
                         "clientSideParameterSet": "Resources_Get",
@@ -75,7 +75,7 @@
                                 "property": "Users"
                             }
                         ]
-                    }
+                    }]
                 }]
             }
         },

--- a/Tests/data/ClientSideFilterTests/ClientSideFilterSpecWithMetadata.json
+++ b/Tests/data/ClientSideFilterTests/ClientSideFilterSpecWithMetadata.json
@@ -46,6 +46,7 @@
                     "clientSideFilter": {
                         "serverSideResultCommand": ".",
                         "serverSideResultParameterSet": "Resources_List",
+                        "clientSideParameterSet": "Resources_Get",
                         "filters": [
                             {
                                 "type": "wildcard",
@@ -54,7 +55,8 @@
                                 "property": "Name"
                             },
                             {
-                                "type": "lessThanLogical",
+                                "type": "logicalOperation",
+                                "operation": ">=",
                                 "parameter": "LastCreatedOn",
                                 "appendParameterInfo": {
                                     "type": "System.DateTime",
@@ -63,7 +65,8 @@
                                 "property": "CreatedOn"
                             },
                             {
-                                "type": "lessThanLogical",
+                                "type": "logicalOperation",
+                                "operation": "<",
                                 "parameter": "MaxUsers",
                                 "appendParameterInfo": {
                                     "type": "int",

--- a/Tests/run-tests.ps1
+++ b/Tests/run-tests.ps1
@@ -9,7 +9,6 @@
 #########################################################################################
 [CmdletBinding()]
 param(
-    [ValidateSet("All", "UnitTest", "ScenarioTest")]
     [string[]]$TestSuite = "All",
     [string[]]$TestName,
     [ValidateSet("net452", "netstandard1.7")]

--- a/Tests/run-tests.ps1
+++ b/Tests/run-tests.ps1
@@ -9,7 +9,9 @@
 #########################################################################################
 [CmdletBinding()]
 param(
+    [ValidateSet("All", "UnitTest", "ScenarioTest")]
     [string[]]$TestSuite = "All",
+    [string]$Tag,
     [string[]]$TestName,
     [ValidateSet("net452", "netstandard1.7")]
     [string]$TestFramework = "net452",
@@ -155,7 +157,7 @@ $srcPath += [System.IO.Path]::DirectorySeparatorChar
 $executeTestsCommand += @"
     ;`$verbosepreference=`'continue`';
     `$env:PSModulePath=`"$srcPath;$modulePath;`$env:PSModulePath`";
-    Invoke-Pester -Script `'$PSScriptRoot`' -ExcludeTag KnownIssue -OutputFormat NUnitXml -OutputFile ScenarioTestResults.xml -Verbose;
+    Invoke-Pester -Script `'$PSScriptRoot`' -ExcludeTag KnownIssue -OutputFormat NUnitXml -OutputFile ScenarioTestResults.xml -Verbose
 "@
 # Set up Pester params
 $pesterParams = @{'ExcludeTag' = 'KnownIssue'; 'OutputFormat' = 'NUnitXml'; 'OutputFile' = 'TestResults.xml'}
@@ -163,14 +165,15 @@ if ($PSBoundParameters.ContainsKey('TestName')) {
     $executeTestsCommand += " -TestName `"$TestName`""
 }
 
-if ($TestSuite.Contains("All")) {
+if (-not $Tag) {
     Write-Verbose "Invoking all tests."
 }
 else {
-    Write-Verbose "Running only tests with tag: $TestSuite"
-    $executeTestsCommand += " -Tag $TestSuite"
+    Write-Verbose "Running only tests with tag: $Tag"
+    $executeTestsCommand += " -Tag $Tag"
 }
 
+$executeTestsCommand += ";"
 Write-Verbose "Dependency versions:"
 Write-Verbose " -- AzureRM.Profile: $($azureRmProfile.Version)"
 Write-Verbose " -- Pester: $((get-command invoke-pester).Version)"

--- a/docs/extensions/readme.md
+++ b/docs/extensions/readme.md
@@ -38,6 +38,7 @@ hostOverrideCommand | `string` | Specify a PowerShell cmdlet that should return 
 noAuthChallenge | `bool` | Specify true to indicate that the service will not offer an authentication challenge, such as adding the WWW-Authenticate header to a 401 response. Default is false.
 formatter | `string` | Specify a formatter to use. One of: 'None', 'PSScriptAnalyzer'
 defaultWildcardChar | `character` | Default wildcard character for auto-generated client-side filtering. Defaults to '%'.
+azureDefaults | `x-ps-msazure-defaults` | Defaults for Microsoft Azure services.
 
 **Note**: These field names are taken from New-PSSwaggerModule cmdlet parameters. These field names will be renamed as per the cmdlet review updates for New-PSSwaggerModule cmdlet.
 
@@ -387,7 +388,7 @@ Defines a single client-side filter
 
 Field Name | Type | Description
 ---|:---:|---
-type | `string` | Type of filter. Supported: 'wildcard', 'equalityOperator'. See: Filter Types
+type | `string` | Type of filter. Supported: 'wildcard', 'equalityOperator', 'powershellWildcard'. See: Filter Types
 parameter | `string` | Parameter containing the filter pattern or value.
 property | `string` | Property of the result object to filter on.
 appendParameterInfo | `x-ps-client-side-filter-definition[]` | Append this parameter to the cmdlet parameter list. Shouldn't be used if the parameter already exists. Properties: 'type' = PowerShell type name, 'required' = true or false if the new parameter should be required
@@ -407,6 +408,24 @@ appendParameterInfo | `x-ps-client-side-filter-definition[]` | Append this param
 }
 ```
 
+## x-ps-msazure-defaults
+Default settings for Microsoft Azure services.
+
+**Parent element**: `x-ps-code-generation-settings Object`
+
+**Schema**:
+
+Field Name | Type | Description
+---|:---:|---
+* | * | Additional properties for the current filter type. 'wildcard': 'character'. 'equalityOperator': 'operation'
+
+**Examples**:
+```json5
+{
+    "clientSideFiltering": true
+}
+```
+
 ## Filter Types
 ### Wildcard
 Replaces all instances of the wildcard character with ".*" and applies the input value as a regular expression. For example, the input "*a" is turned into the regular expression ".*a".
@@ -419,3 +438,6 @@ Applies an equality operation. The right operand is the input value, while the l
 
 -- Additional properties
 Operation - one of: "<", "<=", "=", ">=", ">"
+
+### PowerShellWildcard
+Uses the PowerShell wildcard patterns ("*", "[", "?") to match. See the class "System.Management.Automation.WildcardPattern".

--- a/docs/extensions/readme.md
+++ b/docs/extensions/readme.md
@@ -114,7 +114,7 @@ generateCommand | `bool` | Boolean to indicate whether a cmdlet is required or n
 defaultParameterSet | `string` | String value to indicate whether the specified OperationId or Definition name as the default parameter set name when multiple Operations or definitions are merged into the same cmdlet, e.g., Get and List operationIds can be combined into single cmdlet.
 generateOutputFormat | `bool` | Applicable to definitions only. Boolean to indicate whether output format file is required for this model type or not. Default value true.
 clientParameters | `x-ps-client-parameters` | Client parameters for this command. Overrides global parameters.
-clientSideFilter | `x-ps-client-side-filter` | Client-side filter.
+clientSideFilters | `x-ps-client-side-filter[]` | Client-side filter.
 
 **Examples**:
 1. x-ps-cmdlet-infos on operation

--- a/docs/extensions/readme.md
+++ b/docs/extensions/readme.md
@@ -37,6 +37,7 @@ customAuthCommand | `string` | Specify a PowerShell cmdlet that should return a 
 hostOverrideCommand | `string` | Specify a PowerShell cmdlet that should return a custom hostname string. Overrides the default host in the specification.
 noAuthChallenge | `bool` | Specify true to indicate that the service will not offer an authentication challenge, such as adding the WWW-Authenticate header to a 401 response. Default is false.
 formatter | `string` | Specify a formatter to use. One of: 'None', 'PSScriptAnalyzer'
+defaultWildcardChar | `character` | Default wildcard character for auto-generated client-side filtering.
 
 **Note**: These field names are taken from New-PSSwaggerModule cmdlet parameters. These field names will be renamed as per the cmdlet review updates for New-PSSwaggerModule cmdlet.
 
@@ -113,6 +114,7 @@ generateCommand | `bool` | Boolean to indicate whether a cmdlet is required or n
 defaultParameterSet | `string` | String value to indicate whether the specified OperationId or Definition name as the default parameter set name when multiple Operations or definitions are merged into the same cmdlet, e.g., Get and List operationIds can be combined into single cmdlet.
 generateOutputFormat | `bool` | Applicable to definitions only. Boolean to indicate whether output format file is required for this model type or not. Default value true.
 clientParameters | `x-ps-client-parameters` | Client parameters for this command. Overrides global parameters.
+clientSideFilter | `x-ps-client-side-filter` | Client-side filter.
 
 **Examples**:
 1. x-ps-cmdlet-infos on operation
@@ -351,3 +353,57 @@ LongRunningOperationRetryTimeout | `int` | Retry timeout in seconds for Long Run
     "LongRunningOperationRetryTimeout": 9001
 }
 ```
+
+## x-ps-client-side-filter
+Defines client-side filters
+
+**Parent element**: `x-ps-cmdlet-info Object`
+
+**Schema**:
+
+Field Name | Type | Description
+---|:---:|---
+serverSideResultCommand | `string` | Cmdlet to run to get server-side results. Use "." to indicate the current cmdlet.
+serverSideResultParameterSet | `string` | Parameter set to get server-side results.
+clientSideParameterSet | `string` | Parameter set to get parameters from.
+filters | `x-ps-client-side-filter-definition[]` | Filters
+
+**Examples**:
+```json5
+{
+    "serverSideResultCommand": ".",
+    "serverSideResultParameterSet": "BatchAccount_List",
+    "clientSideParameterSet": "BatchAccount_Get",
+    "filters": ...
+}
+```
+
+## x-ps-client-side-filter-definition
+Defines a single client-side filter
+
+**Parent element**: `x-ps-client-side-filter Object`
+
+**Schema**:
+
+Field Name | Type | Description
+---|:---:|---
+type | `string` | Type of filter. Supported: 'wildcard', 'logicalOperation'
+parameter | `string` | Parameter containing the filter pattern or value.
+property | `string` | Property of the result object to filter on.
+appendParameterInfo | `x-ps-client-side-filter-definition[]` | Append this parameter to the cmdlet parameter list. Shouldn't be used if the parameter already exists. Properties: 'type' = PowerShell type name, 'required' = true or false if the new parameter should be required
+* | * | Additional properties for the current filter type. 'wildcard': 'character'. 'logicalOperation': 'operation'
+
+**Examples**:
+```json5
+{
+    "type": "wildcard",
+    "parameter": "Name",
+    "property": "Name",
+    "character": "*",
+    "appendParameterInfo": {
+        "type": "int",
+        "required": false
+    }
+}
+```
+

--- a/docs/extensions/readme.md
+++ b/docs/extensions/readme.md
@@ -37,7 +37,7 @@ customAuthCommand | `string` | Specify a PowerShell cmdlet that should return a 
 hostOverrideCommand | `string` | Specify a PowerShell cmdlet that should return a custom hostname string. Overrides the default host in the specification.
 noAuthChallenge | `bool` | Specify true to indicate that the service will not offer an authentication challenge, such as adding the WWW-Authenticate header to a 401 response. Default is false.
 formatter | `string` | Specify a formatter to use. One of: 'None', 'PSScriptAnalyzer'
-defaultWildcardChar | `character` | Default wildcard character for auto-generated client-side filtering.
+defaultWildcardChar | `character` | Default wildcard character for auto-generated client-side filtering. Defaults to '%'.
 
 **Note**: These field names are taken from New-PSSwaggerModule cmdlet parameters. These field names will be renamed as per the cmdlet review updates for New-PSSwaggerModule cmdlet.
 
@@ -412,7 +412,7 @@ appendParameterInfo | `x-ps-client-side-filter-definition[]` | Append this param
 Replaces all instances of the wildcard character with ".*" and applies the input value as a regular expression. For example, the input "*a" is turned into the regular expression ".*a".
 
 -- Additional properties
-Character - a single character denoting the wildcard character, e.g. "*"
+Character - a single character denoting the wildcard character, e.g. "*". Defaults to '%' if not specified.
 
 ### EqualityOperator
 Applies an equality operation. The right operand is the input value, while the left operand is the value of the object property specified.

--- a/docs/extensions/readme.md
+++ b/docs/extensions/readme.md
@@ -387,11 +387,11 @@ Defines a single client-side filter
 
 Field Name | Type | Description
 ---|:---:|---
-type | `string` | Type of filter. Supported: 'wildcard', 'logicalOperation'
+type | `string` | Type of filter. Supported: 'wildcard', 'equalityOperator'. See: Filter Types
 parameter | `string` | Parameter containing the filter pattern or value.
 property | `string` | Property of the result object to filter on.
 appendParameterInfo | `x-ps-client-side-filter-definition[]` | Append this parameter to the cmdlet parameter list. Shouldn't be used if the parameter already exists. Properties: 'type' = PowerShell type name, 'required' = true or false if the new parameter should be required
-* | * | Additional properties for the current filter type. 'wildcard': 'character'. 'logicalOperation': 'operation'
+* | * | Additional properties for the current filter type. 'wildcard': 'character'. 'equalityOperator': 'operation'
 
 **Examples**:
 ```json5
@@ -407,3 +407,15 @@ appendParameterInfo | `x-ps-client-side-filter-definition[]` | Append this param
 }
 ```
 
+## Filter Types
+### Wildcard
+Replaces all instances of the wildcard character with ".*" and applies the input value as a regular expression. For example, the input "*a" is turned into the regular expression ".*a".
+
+-- Additional properties
+Character - a single character denoting the wildcard character, e.g. "*"
+
+### EqualityOperator
+Applies an equality operation. The right operand is the input value, while the left operand is the value of the object property specified.
+
+-- Additional properties
+Operation - one of: "<", "<=", "=", ">=", ">"


### PR DESCRIPTION
Fixes:
- Quick fix for when psmeta file doesn't contain optional properties

Features:
- Client-side filtering support. Azure/AzureStack will automatically add client-side filtering for the "Name" property of the object when *_Get and *_List cmdlets are combined. In general usage, this feature is not recommended. Multiple filters are AND'd together.
- run-tests.ps1 has -Tag support

Example of filtering:
```PowerShell
# Get all batch accounts
$accounts = Get-BatchAccount
$accounts.Count # 3
$accounts.Name # "test", "tom", "bob"
$accounts = Get-BatchAccount -Name test -ResourceGroupName test
$accounts.Count # 1
$accounts = Get-BatchAccount -Name t* -ResourceGroupName test
$accounts.Count #2
```